### PR TITLE
DefaultServiceFactory should do nothing during ClassNotFoundException

### DIFF
--- a/modules/util/src/main/java/com/gluonhq/attach/util/impl/DefaultServiceFactory.java
+++ b/modules/util/src/main/java/com/gluonhq/attach/util/impl/DefaultServiceFactory.java
@@ -66,7 +66,7 @@ public class DefaultServiceFactory<T> implements ServiceFactory<T> {
         } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | SecurityException | IllegalArgumentException | InvocationTargetException ex) {
             Logger.getLogger(DefaultServiceFactory.class.getName()).log(Level.SEVERE, null, ex);
         } catch (ClassNotFoundException ex) {
-            ex.printStackTrace();
+            // no-op
         }
         Logger.getLogger(DefaultServiceFactory.class.getName()).log(Level.WARNING, "No new instance for " + serviceType);
         return null;


### PR DESCRIPTION
`DefaultServiceFactory` should do nothing when a ClassNotFoundException is thrown