### PR TITLE
#84 Use grandroid_ext.h, copied from Substrate

### DIFF
--- a/gradle/include/android/grandroid_ext.h
+++ b/gradle/include/android/grandroid_ext.h
@@ -26,11 +26,20 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "grandroid_ext.h"
-#include <android/log.h>
+#include <jni.h>
 
-#define ATTACH_LOG_INFO(...)  ((void)__android_log_print(ANDROID_LOG_INFO,"GluonAttach", __VA_ARGS__))
-#define ATTACH_LOG_FINE(...)  ((void)__android_log_print(ANDROID_LOG_DEBUG,"GluonAttach", __VA_ARGS__))
-#define ATTACH_LOG_FINEST(...)  ((void)__android_log_print(ANDROID_LOG_VERBOSE,"GluonAttach", __VA_ARGS__))
-#define ATTACH_LOG_WARNING(...)  ((void)__android_log_print(ANDROID_LOG_WARN,"GluonAttach", __VA_ARGS__))
-#define ATTACH_LOG_SEVERE(...)  ((void)__android_log_print(ANDROID_LOG_ERROR,"GluonAttach", __VA_ARGS__))
+extern jclass activityClass;
+extern jobject activity;
+
+extern JavaVM *androidVM;
+extern JNIEnv *androidEnv;
+
+// expose AndroidVM, Env, MainActivity and its class
+JavaVM* substrateGetAndroidVM();
+JNIEnv* substrateGetAndroidEnv();
+jclass substrateGetActivityClass();
+jclass substrateGetPermissionActivityClass();
+jobject substrateGetActivity();
+
+// Attach
+void registerAttachMethodHandles(JNIEnv* env);

--- a/modules/position/src/main/native/android/c/Position.c
+++ b/modules/position/src/main/native/android/c/Position.c
@@ -30,8 +30,6 @@
 static JavaVM* graalVM;
 static JNIEnv *graalEnv;
 
-static JNIEnv *androidEnv;
-
 // Graal handles
 static jclass jGraalPositionClass;
 jmethodID jGraalSetLocationMethod;


### PR DESCRIPTION
As follow up of https://github.com/gluonhq/substrate/pull/483, this PR introduces a copy of `grandroid_ext.h` in Attach.
Note this copy should be updated in case the original file changes in Substrate.

Fixes #84