### PR TITLE
#118 Remove reflection config files for desktop for services without …

### DIFF
--- a/modules/accelerometer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/accelerometer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.accelerometer.impl.DesktopAccelerometerService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/accelerometer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/accelerometer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.accelerometer.impl.DesktopAccelerometerService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/accelerometer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/accelerometer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.accelerometer.impl.DesktopAccelerometerService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/augmented-reality/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/augmented-reality/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.ar.impl.DesktopAugmentedRealityService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/augmented-reality/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/augmented-reality/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.ar.impl.DesktopAugmentedRealityService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/augmented-reality/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/augmented-reality/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.ar.impl.DesktopAugmentedRealityService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/barcode-scan/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/barcode-scan/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.barcode.impl.DesktopBarcodeScanService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/barcode-scan/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/barcode-scan/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.barcode.impl.DesktopBarcodeScanService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/barcode-scan/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/barcode-scan/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.barcode.impl.DesktopBarcodeScanService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/battery/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/battery/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.battery.impl.DesktopBatteryService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/battery/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/battery/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.battery.impl.DesktopBatteryService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/battery/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/battery/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.battery.impl.DesktopBatteryService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/ble/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/ble/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.ble.impl.DesktopBleService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/ble/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/ble/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.ble.impl.DesktopBleService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/ble/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/ble/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.ble.impl.DesktopBleService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/browser/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/browser/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.browser.impl.DesktopBrowserService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/browser/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/browser/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.browser.impl.DesktopBrowserService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/browser/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/browser/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.browser.impl.DesktopBrowserService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/compass/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/compass/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.compass.impl.DesktopCompassService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/compass/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/compass/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.compass.impl.DesktopCompassService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/compass/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/compass/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.compass.impl.DesktopCompassService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/connectivity/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/connectivity/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.connectivity.impl.DesktopConnectivityService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/connectivity/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/connectivity/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.connectivity.impl.DesktopConnectivityService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/connectivity/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/connectivity/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.connectivity.impl.DesktopConnectivityService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/device/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/device/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.device.impl.DesktopDeviceService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/device/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/device/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.device.impl.DesktopDeviceService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/device/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/device/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.device.impl.DesktopDeviceService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/dialer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/dialer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.dialer.impl.DesktopDialerService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/dialer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/dialer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.dialer.impl.DesktopDialerService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/dialer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/dialer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.dialer.impl.DesktopDialerService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/in-app-billing/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/in-app-billing/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.inappbilling.impl.DesktopInAppBillingService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/in-app-billing/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/in-app-billing/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.inappbilling.impl.DesktopInAppBillingService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/in-app-billing/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/in-app-billing/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.inappbilling.impl.DesktopInAppBillingService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/local-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/local-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.localnotifications.impl.DesktopLocalNotificationsService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/local-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/local-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.localnotifications.impl.DesktopLocalNotificationsService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/local-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/local-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.localnotifications.impl.DesktopLocalNotificationsService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/magnetometer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/magnetometer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.magnetometer.impl.DesktopMagnetometerService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/magnetometer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/magnetometer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.magnetometer.impl.DesktopMagnetometerService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/magnetometer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/magnetometer/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.magnetometer.impl.DesktopMagnetometerService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/orientation/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/orientation/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.orientation.impl.DesktopOrientationService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/orientation/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/orientation/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.orientation.impl.DesktopOrientationService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/orientation/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/orientation/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.orientation.impl.DesktopOrientationService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/pictures/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/pictures/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.pictures.impl.DesktopPicturesService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/pictures/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/pictures/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.pictures.impl.DesktopPicturesService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/pictures/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/pictures/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.pictures.impl.DesktopPicturesService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/position/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/position/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.position.impl.DesktopPositionService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/position/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/position/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.position.impl.DesktopPositionService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/position/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/position/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.position.impl.DesktopPositionService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/push-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/push-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.pushnotifications.impl.DesktopPushNotificationsService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/push-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/push-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.pushnotifications.impl.DesktopPushNotificationsService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/push-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/push-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.pushnotifications.impl.DesktopPushNotificationsService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/share/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/share/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.share.impl.DesktopShareService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/share/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/share/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.share.impl.DesktopShareService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/share/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/share/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.share.impl.DesktopShareService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/statusbar/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/statusbar/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.statusbar.impl.DesktopStatusBarService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/statusbar/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/statusbar/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.statusbar.impl.DesktopStatusBarService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/statusbar/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/statusbar/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.statusbar.impl.DesktopStatusBarService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/vibration/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/vibration/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.vibration.impl.DesktopVibrationService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/vibration/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/vibration/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.vibration.impl.DesktopVibrationService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/vibration/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/vibration/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.vibration.impl.DesktopVibrationService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/video/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
+++ b/modules/video/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-darwin.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.video.impl.DesktopVideoService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/video/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
+++ b/modules/video/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-linux.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.video.impl.DesktopVideoService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]

--- a/modules/video/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
+++ b/modules/video/src/main/resources/META-INF/substrate/config/reflectionconfig-x86_64-windows.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name" : "com.gluonhq.attach.video.impl.DesktopVideoService",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]


### PR DESCRIPTION
…desktop implementation

Fixes #118 

If a Service that has no Desktop implementation is added with `desktop` classifier to the classpath and to the reflection list, native compile will fail because the Desktop class that is added to the reflection list is not found.

This PR removes the reflection files that contain non existing classes.