### PR TITLE
Include third party dependencies in BarcodeScanService for Android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'io.codearte.nexus-staging' version '0.21.1'
     id 'de.marcphilipp.nexus-publish' version '0.4.0' apply false
-    id "org.openjfx.javafxplugin" version "0.0.8" apply false
+    id "org.openjfx.javafxplugin" version "0.0.9" apply false
 }
 
 apply from: rootProject.file("gradle/native-build.gradle")
@@ -27,10 +27,6 @@ subprojects {
 
     sourceCompatibility = 11
     targetCompatibility = 11
-
-    configurations {
-        androidImplementation
-    }
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'io.codearte.nexus-staging' version '0.21.1'
-    id 'de.marcphilipp.nexus-publish' version '0.4.0' apply false
     id "org.openjfx.javafxplugin" version "0.0.9" apply false
+    id 'de.marcphilipp.nexus-publish' version '0.4.0' apply false
 }
 
 apply from: rootProject.file("gradle/native-build.gradle")

--- a/gradle/android_project/build.gradle
+++ b/gradle/android_project/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.0-alpha09'
+        classpath 'com.kezong:fat-aar:1.2.16'
     }
 }
 

--- a/gradle/android_project/build.gradle
+++ b/gradle/android_project/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.0-alpha09'
-        classpath 'com.kezong:fat-aar:1.2.16'
     }
 }
 

--- a/gradle/native-build.gradle
+++ b/gradle/native-build.gradle
@@ -17,7 +17,8 @@ ext.aarBuild = { buildDir, projectDir, name, os ->
 
     // copy android_project
     File androidDir = file("$projectDir/../../gradle/android_project")
-    def tempDir = File.createTempDir()
+    def tempDir = file("${buildDir}/aar")
+    mkdir tempDir
     project.copy {
         from androidDir
         exclude "**/gradlew"
@@ -92,7 +93,10 @@ ext.aarBuild = { buildDir, projectDir, name, os ->
             into file("$tempDir/library/src/main/res/xml/")
         }
     }
-    project.delete(files("${buildDir}/resources/main/META-INF/substrate/dalvik/"))
+    // prepare output
+    def dalvikOutput = "${buildDir}/resources/main/META-INF/substrate/dalvik/"
+    project.delete(files(dalvikOutput))
+
     // build aar
     file("$tempDir/gradlew")
     def aarArgs = ["-p", file("$tempDir/library").getAbsolutePath(), "assembleDebug"].flatten()
@@ -101,13 +105,15 @@ ext.aarBuild = { buildDir, projectDir, name, os ->
         executable file("$tempDir/gradlew").getAbsolutePath()
         args aarArgs
     }
-    // copy aar
-    def dalvikOutput = "${buildDir}/resources/main/META-INF/substrate/dalvik/"
+
+    // copy aar, dependencies
     project.copy {
         from file("$tempDir/library/build/outputs/aar/library-debug.aar")
+        from file("$projectDir/src/main/resources/META-INF/substrate/dalvik/android-dependencies.txt")
         into dalvikOutput
         rename { fileName -> fileName.replace('library-debug', "$name") }
     }
+    
     println("build for ${name}.aar finished")
     File a = new File("$dalvikOutput/${name}.aar")
     if (a.exists()) {

--- a/modules/barcode-scan/build.gradle
+++ b/modules/barcode-scan/build.gradle
@@ -6,7 +6,6 @@ javafx {
 
 dependencies {
     implementation project(':util')
-    androidImplementation 'com.google.zxing:core:3.4.0'
 }
 
 ext.description = 'Common API to access barcode scan features'

--- a/modules/barcode-scan/src/main/resources/META-INF/substrate/dalvik/android-dependencies.txt
+++ b/modules/barcode-scan/src/main/resources/META-INF/substrate/dalvik/android-dependencies.txt
@@ -1,0 +1,1 @@
+implementation 'com.google.zxing:core:3.4.0'

--- a/modules/barcode-scan/src/main/resources/META-INF/substrate/dalvik/build.gradle
+++ b/modules/barcode-scan/src/main/resources/META-INF/substrate/dalvik/build.gradle
@@ -1,16 +1,17 @@
 apply plugin: 'com.android.library'
+apply plugin: 'com.kezong.fat-aar'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
     }
 
     dependencies {
         provided fileTree(dir: '../libs', include: '*.jar')
-        implementation 'com.google.zxing:core:3.4.0'
+        embed 'com.google.zxing:core:3.4.0'
     }
 
     afterEvaluate {

--- a/modules/barcode-scan/src/main/resources/META-INF/substrate/dalvik/build.gradle
+++ b/modules/barcode-scan/src/main/resources/META-INF/substrate/dalvik/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.kezong.fat-aar'
 
 android {
     compileSdkVersion 29
@@ -11,7 +10,7 @@ android {
 
     dependencies {
         provided fileTree(dir: '../libs', include: '*.jar')
-        embed 'com.google.zxing:core:3.4.0'
+        implementation 'com.google.zxing:core:3.4.0'
     }
 
     afterEvaluate {


### PR DESCRIPTION
Fixes #210 by using the fat-aar plugin, that embeds the third party dependencies into the aar/libs folder.