### PR TITLE
Add Push Notifications implementation for Android

### DIFF
--- a/gradle/android_project/gradle.properties
+++ b/gradle/android_project/gradle.properties
@@ -1,2 +1,3 @@
+android.useAndroidX=true
 org.gradle.daemon=false
 org.gradle.jvmargs=-Xms512M -Xmx4g -XX:MaxPermSize=1024m -XX:MaxMetaspaceSize=1g

--- a/modules/push-notifications/build.gradle
+++ b/modules/push-notifications/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation project(":util")
     implementation project(":runtime-args")
+    implementation 'jakarta.json:jakarta.json-api:1.1.6'
 }
 
 ext.moduleName = 'com.gluonhq.attach.pushnotifications'

--- a/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/PushNotificationsService.java
+++ b/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/PushNotificationsService.java
@@ -102,11 +102,13 @@ import java.util.Optional;
  *    </application>
  *  </manifest>}</pre>
  *
+ * <b>Note</b>: All these modifications are handled automatically by the
+ * <a href="https://docs.gluonhq.com/client">Gluon Client plugin</a> during the package goal.
+ *
  * <p><b>iOS Configuration</b></p>
  *
- * <p>You need to make sure that you set the <code>jfxmobile.ios.apsEnvironment</code> property in the
- * <code>build.gradle</code> of your project to either <code>development</code> or <code>production</code>, matching the
- * configured provisioning profile.</p>
+ * <p>You need to use a Provisioning Profile that defines the <code>aps-environment</code> property in the
+ * <code>Entitlements</code> section to either <code>development</code> or <code>production</code>.</p>
  *
  * @since 3.2.0
  */
@@ -143,5 +145,6 @@ public interface PushNotificationsService {
      * @param authorizedEntity a string that matches the Sender ID of a GCM or FCM application
      * @deprecated
      */
+    @Deprecated
     void register(String authorizedEntity);
 }

--- a/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/PushNotificationsService.java
+++ b/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/PushNotificationsService.java
@@ -55,9 +55,6 @@ import java.util.Optional;
  * <p>The following <code>permissions</code>, <code>services</code> and <code>receiver</code> need to be added to the
  * android manifest configuration file to make push notifications work on android. The main activity also requires the
  * attribute <code>android:launchMode</code> with value <code>singleTop</code>.</p>
- * <p>Also, make sure that you replace <code>$packageName</code> with the value of the <code>package</code> attribute
- * in the <code>manifest</code> element that is defined at the top of your AndroidManifest.xml. You should have replaced
- * the <code>$packageName</code> string three times.</p>
  * <pre>
  * {@code <manifest ...>
  *    ...
@@ -77,7 +74,7 @@ import java.util.Optional;
  *                android:permission="com.google.android.c2dm.permission.SEND" >
  *        <intent-filter>
  *          <action android:name="com.google.android.c2dm.intent.RECEIVE" />
- *          <category android:name="$packageName" />
+ *          <category android:name="${applicationId}" />
  *        </intent-filter>
  *      </receiver>
  *      <service android:name="com.gluonhq.helloandroid.PushFcmMessagingService">
@@ -102,9 +99,6 @@ import java.util.Optional;
  *            <meta-data android:name="android.support.PARENT_ACTIVITY"
  *                       android:value="com.gluonhq.helloandroid.MainActivity"/>
  *      </activity>
- *
- *      <meta-data android:name="com.google.android.gms.version"
- *               android:value="12451000"/>
  *    </application>
  *  </manifest>}</pre>
  *

--- a/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/PushNotificationsService.java
+++ b/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/PushNotificationsService.java
@@ -131,6 +131,17 @@ public interface PushNotificationsService {
     /**
      * Register the app for receiving push notifications. On iOS this will trigger a confirmation dialog that
      * must be accepted by the user.
+     * @since  4.0.10
      */
     void register();
+
+    /**
+     * Register the app for receiving push notifications. On iOS this will trigger a confirmation dialog that
+     * must be accepted by the user. For Android, you need to pass in the authorizedEntity value that matches the
+     * Sender ID of your Google Cloud Messaging or Firebase Cloud Messaging application.
+     *
+     * @param authorizedEntity a string that matches the Sender ID of a GCM or FCM application
+     * @deprecated
+     */
+    void register(String authorizedEntity);
 }

--- a/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/AndroidPushNotificationsService.java
+++ b/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/AndroidPushNotificationsService.java
@@ -69,6 +69,7 @@ public class AndroidPushNotificationsService implements PushNotificationsService
     }
 
     @Override
+    @Deprecated
     public void register(String authorizedEntity) {
         register();
     }

--- a/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/AndroidPushNotificationsService.java
+++ b/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/AndroidPushNotificationsService.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2016, 2020, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.attach.pushnotifications.impl;
+
+import com.gluonhq.attach.pushnotifications.PushNotificationsService;
+import com.gluonhq.attach.pushnotifications.impl.gms.GoogleServicesConfiguration;
+import com.gluonhq.attach.runtimeargs.RuntimeArgsService;
+import com.gluonhq.attach.util.Util;
+import javafx.application.Platform;
+import javafx.beans.property.ReadOnlyStringProperty;
+import javafx.beans.property.ReadOnlyStringWrapper;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * iOS implementation of PushNotificationsService.
+ */
+public class AndroidPushNotificationsService implements PushNotificationsService {
+
+    private static final Logger LOG = Logger.getLogger(AndroidPushNotificationsService.class.getName());
+    private static final boolean debug = Util.DEBUG;
+
+    static {
+        System.loadLibrary("pushnotifications");
+    }
+
+    /**
+     * A string property to wrap the token device when received from the native layer
+     */
+    private static final ReadOnlyStringWrapper TOKEN = new ReadOnlyStringWrapper();
+
+    public AndroidPushNotificationsService() {
+    }
+
+    @Override
+    public ReadOnlyStringProperty tokenProperty() {
+        return TOKEN.getReadOnlyProperty();
+    }
+
+    @Override
+    public void register() {
+        int resultCode = isGooglePlayServicesAvailable();
+        if (resultCode == 0) { // ConnectionResult.SUCCESS
+            if (debug) {
+                LOG.info("Google Play Services is available");
+            }
+            GoogleServicesConfiguration configuration = readGoogleServicesConfiguration();
+            initializeFirebase(configuration.getApplicationId(), configuration.getProjectNumber());
+        } else {
+            LOG.log(Level.SEVERE, "Google Play Services Error:\n" +
+                    getErrorString(resultCode) +
+                    "\n\nPush notifications won't work until this error is fixed");
+        }
+    }
+
+    private GoogleServicesConfiguration readGoogleServicesConfiguration() {
+        GoogleServicesConfiguration configuration = new GoogleServicesConfiguration();
+
+        try (JsonReader reader = Json.createReader(AndroidPushNotificationsService.class.getResourceAsStream("/google-services.json"))) {
+            JsonObject json = reader.readObject();
+
+            JsonObject projectInfo = json.getJsonObject("project_info");
+            if (projectInfo != null) {
+                configuration.setProjectNumber(projectInfo.getString("project_number", null));
+            }
+
+            String packageName = getPackageName();
+            JsonArray clients = json.getJsonArray("client");
+            if (clients != null) {
+                for (int i = 0; i < clients.size(); i++) {
+                    JsonObject client = clients.getJsonObject(i);
+                    JsonObject clientInfo = client.getJsonObject("client_info");
+                    if (clientInfo != null) {
+                        JsonObject androidClientInfo = clientInfo.getJsonObject("android_client_info");
+                        if (androidClientInfo != null) {
+                            String clientPackageName = androidClientInfo.getString("package_name", "");
+                            if (packageName.equals(clientPackageName)) {
+                                configuration.setApplicationId(clientInfo.getString("mobilesdk_app_id", null));
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "Failed to read google-services.json. Make sure to add the file to the folder: src/android/resources", e);
+        }
+
+        if (debug) {
+            LOG.info("Got configuration: " + configuration);
+        }
+        return configuration;
+    }
+
+    // native
+    private native String getPackageName();
+    private native int isGooglePlayServicesAvailable();
+    private native String getErrorString(int resultCode);
+    private native void initializeFirebase(String applicationId, String projectNumber);
+
+    // callback
+    private static void setToken(String token) {
+        if (token == null) {
+            return;
+        }
+        if (debug) {
+            LOG.info("Registered successfully for Push Notifications with token: " + token);
+        }
+        Platform.runLater(() -> TOKEN.setValue(token));
+    }
+
+    private static void processRuntimeArgs(String key, String value) {
+        RuntimeArgsService.create().ifPresent(ra -> ra.fire(key, value));
+    }
+
+}

--- a/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/AndroidPushNotificationsService.java
+++ b/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/AndroidPushNotificationsService.java
@@ -69,6 +69,11 @@ public class AndroidPushNotificationsService implements PushNotificationsService
     }
 
     @Override
+    public void register(String authorizedEntity) {
+        register();
+    }
+
+    @Override
     public void register() {
         int resultCode = isGooglePlayServicesAvailable();
         if (resultCode == 0) { // ConnectionResult.SUCCESS

--- a/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/IOSPushNotificationsService.java
+++ b/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/IOSPushNotificationsService.java
@@ -65,6 +65,11 @@ public class IOSPushNotificationsService implements PushNotificationsService {
     }
 
     @Override
+    public void register(String authorizedEntity) {
+        register();
+    }
+
+    @Override
     public void register() {
         initPushNotifications();
     }

--- a/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/IOSPushNotificationsService.java
+++ b/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/IOSPushNotificationsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Gluon
+ * Copyright (c) 2016, 2020, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,14 +29,21 @@ package com.gluonhq.attach.pushnotifications.impl;
 
 import com.gluonhq.attach.pushnotifications.PushNotificationsService;
 import com.gluonhq.attach.runtimeargs.RuntimeArgsService;
+import com.gluonhq.attach.util.Util;
 import javafx.application.Platform;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * iOS implementation of PushNotificationsService.
  */
 public class IOSPushNotificationsService implements PushNotificationsService {
+
+    private static final Logger LOG = Logger.getLogger(IOSPushNotificationsService.class.getName());
+    private static final boolean debug = Util.DEBUG;
 
     static {
         System.loadLibrary("PushNotifications");
@@ -58,7 +65,7 @@ public class IOSPushNotificationsService implements PushNotificationsService {
     }
 
     @Override
-    public void register(String authorizedEntity) {
+    public void register() {
         initPushNotifications();
     }
 
@@ -69,7 +76,7 @@ public class IOSPushNotificationsService implements PushNotificationsService {
      * @param s String with the error description
      */
     private static void failToRegisterForRemoteNotifications(String s) {
-        Platform.runLater(() -> System.out.println("Failed registering Push Notifications with error: " + s));
+        Platform.runLater(() -> LOG.log(Level.WARNING, "Failed registering Push Notifications with error: " + s));
     }
 
     /**
@@ -78,6 +85,9 @@ public class IOSPushNotificationsService implements PushNotificationsService {
     private static void didRegisterForRemoteNotifications(String token) {
         if (token == null) {
             return;
+        }
+        if (debug) {
+            LOG.info("Registered successfully for Push Notifications with token: " + token);
         }
         Platform.runLater(() -> TOKEN.setValue(token));
     }

--- a/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/IOSPushNotificationsService.java
+++ b/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/IOSPushNotificationsService.java
@@ -65,6 +65,7 @@ public class IOSPushNotificationsService implements PushNotificationsService {
     }
 
     @Override
+    @Deprecated
     public void register(String authorizedEntity) {
         register();
     }

--- a/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/gms/GoogleServicesConfiguration.java
+++ b/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/impl/gms/GoogleServicesConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Gluon
+ * Copyright (c) 2020, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,13 +25,34 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-module com.gluonhq.attach.pushnotifications {
+package com.gluonhq.attach.pushnotifications.impl.gms;
 
-    requires transitive javafx.graphics;
-    requires java.json;
-    requires com.gluonhq.attach.util;
-    requires com.gluonhq.attach.runtimeargs;
+public class GoogleServicesConfiguration {
 
-    exports com.gluonhq.attach.pushnotifications;
-    exports com.gluonhq.attach.pushnotifications.impl to com.gluonhq.attach.util;
+    private String applicationId;
+    private String projectNumber;
+
+    public void setApplicationId(String applicationId) {
+        this.applicationId = applicationId;
+    }
+
+    public String getApplicationId() {
+        return applicationId;
+    }
+
+    public void setProjectNumber(String projectNumber) {
+        this.projectNumber = projectNumber;
+    }
+
+    public String getProjectNumber() {
+        return projectNumber;
+    }
+
+    @Override
+    public String toString() {
+        return "GoogleServicesConfiguration{" +
+                "applicationId='" + applicationId + '\'' +
+                ", projectNumber='" + projectNumber + '\'' +
+                '}';
+    }
 }

--- a/modules/push-notifications/src/main/native/android/c/pushnotifications.c
+++ b/modules/push-notifications/src/main/native/android/c/pushnotifications.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2020, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "pushnotifications.h"
+
+// Graal handles
+static jclass jGraalPushNotificationsClass;
+static jmethodID jGraalSetTokenMethod;
+static jmethodID jGraalPushNotificationsProcessMethod;
+
+static jobject jDalvikPushNotificationsService;
+jmethodID jDalvikPushNotificationsServiceGetPackageName;
+jmethodID jDalvikPushNotificationsServiceIsGooglePlayServicesAvailable;
+jmethodID jDalvikPushNotificationsServiceGetErrorString;
+jmethodID jDalvikPushNotificationsServiceInitializeFirebase;
+
+static void initializeGraalHandles(JNIEnv* env) {
+    jGraalPushNotificationsClass = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "com/gluonhq/attach/pushnotifications/impl/AndroidPushNotificationsService"));
+    jGraalSetTokenMethod = (*env)->GetStaticMethodID(env, jGraalPushNotificationsClass, "setToken", "(Ljava/lang/String;)V");
+    jGraalPushNotificationsProcessMethod = (*env)->GetStaticMethodID(env, jGraalPushNotificationsClass, "processRuntimeArgs", "(Ljava/lang/String;Ljava/lang/String;)V");
+}
+
+static void initializePushNotificationsDalvikHandles() {
+    jclass activityClass = substrateGetActivityClass();
+    jclass jPushNotificationsServiceClass = substrateGetPushNotificationsServiceClass();
+
+    ATTACH_DALVIK();
+    jDalvikPushNotificationsServiceGetPackageName = (*dalvikEnv)->GetMethodID(dalvikEnv, jPushNotificationsServiceClass, "getPackageName", "()java/lang/String;");
+    jDalvikPushNotificationsServiceIsGooglePlayServicesAvailable = (*dalvikEnv)->GetMethodID(dalvikEnv, jPushNotificationsServiceClass, "isGooglePlayServicesAvailable", "()I");
+    jDalvikPushNotificationsServiceGetErrorString = (*dalvikEnv)->GetMethodID(dalvikEnv, jPushNotificationsServiceClass, "getErrorString", "(I)java/lang/String;");
+    jDalvikPushNotificationsServiceInitializeFirebase = (*dalvikEnv)->GetMethodID(dalvikEnv, jPushNotificationsServiceClass, "initializeFirebase", "(Ljava/lang/String;Ljava/lang/String;)V");
+
+    jmethodID jPushNotificationsServiceInitMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jPushNotificationsServiceClass, "<init>", "(Landroid/app/Activity;)V");
+    jthrowable t = (*dalvikEnv)->ExceptionOccurred(dalvikEnv);
+    if (t) {
+        ATTACH_LOG_INFO("EXCEPTION occurred when dealing with dalvik handles\n");
+        (*dalvikEnv)->ExceptionClear(dalvikEnv);
+    }
+
+    jobject jActivity = substrateGetActivity();
+    jobject jObj = (*dalvikEnv)->NewObject(dalvikEnv, jPushNotificationsServiceClass, jPushNotificationsServiceInitMethod, jActivity);
+    jDalvikPushNotificationsService = (jobject)(*dalvikEnv)->NewGlobalRef(dalvikEnv, jObj);
+    DETACH_DALVIK();
+}
+
+//////////////////////////
+// From Graal to native //
+//////////////////////////
+
+JNIEXPORT jint JNICALL
+JNI_OnLoad_pushnotifications(JavaVM *vm, void *reserved)
+{
+#ifdef JNI_VERSION_1_8
+    JNIEnv* graalEnv;
+    if ((*vm)->GetEnv(vm, (void **)&graalEnv, JNI_VERSION_1_8) != JNI_OK) {
+        ATTACH_LOG_WARNING("Error initializing native PushNotifications from OnLoad");
+        return JNI_FALSE;
+    }
+    ATTACH_LOG_FINE("Initializing native PushNotifications from OnLoad");
+    initializeGraalHandles(graalEnv);
+    initializePushNotificationsDalvikHandles();
+    ATTACH_LOG_FINE("Initializing native PushNotifications from OnLoad Done");
+    return JNI_VERSION_1_8;
+#else
+    #error Error: Java 8+ SDK is required to compile Attach
+#endif
+}
+
+// from Java to Android
+
+JNIEXPORT jstring JNICALL Java_com_gluonhq_attach_pushnotifications_impl_AndroidPushNotificationsService_getPackageName
+(JNIEnv *env, jobject service) {
+    ATTACH_DALVIK();
+    jstring dalvikPackageName = (jstring) (*dalvikEnv)->CallObjectMethod(dalvikEnv, jDalvikPushNotificationsService, jDalvikPushNotificationsServiceGetPackageName);
+    const char *packageNameChars = (*dalvikEnv)->GetStringUTFChars(dalvikEnv, dalvikPackageName, NULL);
+    jstring graalPackageName = (*env)->NewStringUTF(env, packageNameChars);
+    (*dalvikEnv)->ReleaseStringUTFChars(dalvikEnv, dalvikPackageName, packageNameChars);
+    DETACH_DALVIK();
+    return graalPackageName;
+}
+
+JNIEXPORT jint JNICALL Java_com_gluonhq_attach_pushnotifications_impl_AndroidPushNotificationsService_isGooglePlayServicesAvailable
+(JNIEnv *env, jobject service) {
+    ATTACH_DALVIK();
+    jint available = (*dalvikEnv)->CallIntMethod(dalvikEnv, jDalvikPushNotificationsService, jDalvikPushNotificationsServiceIsGooglePlayServicesAvailable);
+    DETACH_DALVIK();
+    return available;
+}
+
+JNIEXPORT jstring JNICALL Java_com_gluonhq_attach_pushnotifications_impl_AndroidPushNotificationsService_getErrorString
+(JNIEnv *env, jobject service, jint resultCode) {
+    ATTACH_DALVIK();
+    jstring dalvikErrorString = (jstring) (*dalvikEnv)->CallObjectMethod(dalvikEnv, jDalvikPushNotificationsService, jDalvikPushNotificationsServiceGetErrorString,
+                resultCode);
+    const char *errorStringChars = (*dalvikEnv)->GetStringUTFChars(dalvikEnv, dalvikErrorString, NULL);
+    if (debugAttach) {
+        ATTACH_LOG_FINE("PushNotification error string: %s", errorStringChars);
+    }
+    jstring graalErrorString = (*env)->NewStringUTF(env, errorStringChars);
+    (*dalvikEnv)->ReleaseStringUTFChars(dalvikEnv, dalvikErrorString, errorStringChars);
+    DETACH_DALVIK();
+    return graalErrorString;
+}
+
+JNIEXPORT void JNICALL Java_com_gluonhq_attach_pushnotifications_impl_AndroidPushNotificationsService_initializeFirebase
+(JNIEnv *env, jobject service, jstring applicationId, jstring projectNumber) {
+    const char *applicationIdChars = (*env)->GetStringUTFChars(env, applicationId, NULL);
+    const char *projectNumberChars = (*env)->GetStringUTFChars(env, projectNumber, NULL);
+    if (debugAttach) {
+        ATTACH_LOG_FINE("PushNotification::initializeFirebase with app Id: %s and project number: %s", applicationIdChars, projectNumberChars);
+    }
+    ATTACH_DALVIK();
+    jstring dalvikApplicationId = (*dalvikEnv)->NewStringUTF(dalvikEnv, applicationIdChars);
+    jstring dalvikProjectNumber = (*dalvikEnv)->NewStringUTF(dalvikEnv, projectNumberChars);
+    (*dalvikEnv)->CallVoidMethod(dalvikEnv, jDalvikPushNotificationsService, jDalvikPushNotificationsServiceInitializeFirebase,
+                                                        dalvikApplicationId, dalvikProjectNumber);
+    (*dalvikEnv)->DeleteLocalRef(dalvikEnv, dalvikApplicationId);
+    (*dalvikEnv)->DeleteLocalRef(dalvikEnv, dalvikProjectNumber);
+    DETACH_DALVIK();
+    (*env)->ReleaseStringUTFChars(env, applicationId, applicationIdChars);
+    (*env)->ReleaseStringUTFChars(env, projectNumber, projectNumberChars);
+}
+
+///////////////////////////
+// From Dalvik to native //
+///////////////////////////
+
+JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_PushInstanceIdService_sendToken
+    (JNIEnv *env, jobject service, jstring jtoken) {
+    const char *tokenChars = (*env)->GetStringUTFChars(env, jtoken, NULL);
+    if (debugAttach) {
+        ATTACH_LOG_FINE("PushNotifications:: Native layer got token: %s", tokenChars);
+    }
+    ATTACH_GRAAL();
+    jstring jTokenChars = (*graalEnv)->NewStringUTF(graalEnv, tokenChars);
+    (*graalEnv)->CallStaticVoidMethod(graalEnv, jGraalPushNotificationsClass, jGraalSetTokenMethod, jTokenChars);
+    (*graalEnv)->DeleteLocalRef(graalEnv, jTokenChars);
+    DETACH_GRAAL();
+    (*env)->ReleaseStringUTFChars(env, jtoken, tokenChars);
+}
+
+JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_DalvikPushNotificationsService_processRuntimeArgs
+    (JNIEnv *env, jobject service, jstring jkey, jstring jvalue) {
+    const char *keyChars = (*env)->GetStringUTFChars(env, jkey, NULL);
+    const char *valueChars = (*env)->GetStringUTFChars(env, jvalue, NULL);
+    if (debugAttach) {
+        ATTACH_LOG_FINE("PushNotifications:: Native layer got key: %s, value: %s", keyChars, valueChars);
+    }
+    ATTACH_GRAAL();
+    jstring jKeyChars = (*graalEnv)->NewStringUTF(graalEnv, keyChars);
+    jstring jValueChars = (*graalEnv)->NewStringUTF(graalEnv, valueChars);
+    (*graalEnv)->CallStaticVoidMethod(graalEnv, jGraalPushNotificationsClass, jGraalPushNotificationsProcessMethod, jKeyChars, jValueChars);
+    (*graalEnv)->DeleteLocalRef(graalEnv, jKeyChars);
+    (*graalEnv)->DeleteLocalRef(graalEnv, jValueChars);
+    DETACH_GRAAL();
+    (*env)->ReleaseStringUTFChars(env, jkey, keyChars);
+    (*env)->ReleaseStringUTFChars(env, jvalue, valueChars);
+}

--- a/modules/push-notifications/src/main/native/android/c/pushnotifications.c
+++ b/modules/push-notifications/src/main/native/android/c/pushnotifications.c
@@ -49,9 +49,9 @@ static void initializePushNotificationsDalvikHandles() {
     jclass jPushNotificationsServiceClass = substrateGetPushNotificationsServiceClass();
 
     ATTACH_DALVIK();
-    jDalvikPushNotificationsServiceGetPackageName = (*dalvikEnv)->GetMethodID(dalvikEnv, jPushNotificationsServiceClass, "getPackageName", "()java/lang/String;");
+    jDalvikPushNotificationsServiceGetPackageName = (*dalvikEnv)->GetMethodID(dalvikEnv, jPushNotificationsServiceClass, "getPackageName", "()Ljava/lang/String;");
     jDalvikPushNotificationsServiceIsGooglePlayServicesAvailable = (*dalvikEnv)->GetMethodID(dalvikEnv, jPushNotificationsServiceClass, "isGooglePlayServicesAvailable", "()I");
-    jDalvikPushNotificationsServiceGetErrorString = (*dalvikEnv)->GetMethodID(dalvikEnv, jPushNotificationsServiceClass, "getErrorString", "(I)java/lang/String;");
+    jDalvikPushNotificationsServiceGetErrorString = (*dalvikEnv)->GetMethodID(dalvikEnv, jPushNotificationsServiceClass, "getErrorString", "(I)Ljava/lang/String;");
     jDalvikPushNotificationsServiceInitializeFirebase = (*dalvikEnv)->GetMethodID(dalvikEnv, jPushNotificationsServiceClass, "initializeFirebase", "(Ljava/lang/String;Ljava/lang/String;)V");
 
     jmethodID jPushNotificationsServiceInitMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jPushNotificationsServiceClass, "<init>", "(Landroid/app/Activity;)V");

--- a/modules/push-notifications/src/main/native/android/c/pushnotifications.h
+++ b/modules/push-notifications/src/main/native/android/c/pushnotifications.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Gluon
+ * Copyright (c) 2020, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,13 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-module com.gluonhq.attach.pushnotifications {
 
-    requires transitive javafx.graphics;
-    requires java.json;
-    requires com.gluonhq.attach.util;
-    requires com.gluonhq.attach.runtimeargs;
+#include "util.h"
 
-    exports com.gluonhq.attach.pushnotifications;
-    exports com.gluonhq.attach.pushnotifications.impl to com.gluonhq.attach.util;
-}
+jclass substrateGetPushNotificationsServiceClass();

--- a/modules/push-notifications/src/main/native/android/dalvik/DalvikPushNotificationsService.java
+++ b/modules/push-notifications/src/main/native/android/dalvik/DalvikPushNotificationsService.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2016, 2020, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.helloandroid;
+
+import android.app.Activity;
+import android.app.job.JobInfo;
+import android.app.job.JobScheduler;
+import android.content.ComponentName;
+import android.content.Context;
+import android.os.Build;
+import android.util.Log;
+
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+
+public class DalvikPushNotificationsService {
+
+    static final String LAUNCH_PUSH_NOTIFICATION_KEY = "Launch.PushNotification";
+    private static final String TAG = Util.TAG;
+    private static final boolean debug = Util.isDebug();
+
+    private static Activity activity;
+
+    public DalvikPushNotificationsService(Activity activity) {
+        DalvikPushNotificationsService.this.activity = activity;
+    }
+
+    static Activity getActivity() {
+        return activity;
+    }
+
+    public String getPackageName() {
+        return activity.getPackageName();
+    }
+
+    public int isGooglePlayServicesAvailable() {
+        if (debug) {
+            Log.d(TAG, "Checking if Google Play Services is available on device");
+        }
+
+        GoogleApiAvailability apiAvailability = GoogleApiAvailability.getInstance();
+        int resultCode = apiAvailability.isGooglePlayServicesAvailable(activity);
+        if (resultCode != ConnectionResult.SUCCESS) {
+            Log.w(TAG, String.format("Google Play Services Error: %s", apiAvailability.getErrorString(resultCode)));
+        } else {
+            if (debug) {
+                Log.d(TAG, "Google Play Services found");
+            }
+        }
+        return resultCode;
+    }
+
+    public String getErrorString(int resultCode) {
+        GoogleApiAvailability apiAvailability = GoogleApiAvailability.getInstance();
+        return apiAvailability.getErrorString(resultCode);
+    }
+
+    public void initializeFirebase(String applicationId, String projectNumber) {
+        if (debug) {
+            Log.d(TAG, "Initializing Firebase for application " + applicationId + " and project number " + projectNumber);
+        }
+
+        FirebaseApp firebaseApp = FirebaseApp.initializeApp(activity, new FirebaseOptions.Builder()
+                .setApplicationId(applicationId)
+                .setGcmSenderId(projectNumber)
+                .build());
+
+        Log.i(TAG, "FirebaseApp initialized succesfully: " + firebaseApp);
+
+        // schedule a job that triggers every hour and only prints out a single line
+        // this is a way to allow the app to keep receiving push notifications, even
+        // in case the app was closed forcibly
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            JobInfo jobInfo = new JobInfo.Builder(PushNotificationJobService.JOB_ID, new ComponentName(activity, PushNotificationJobService.class))
+                    .setPersisted(true)
+                    .setPeriodic(1000 * 60 * 60) // every hour
+                    .build();
+
+            JobScheduler scheduler = (JobScheduler) activity.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+            scheduler.schedule(jobInfo);
+        }
+    }
+
+    static void sendRuntimeArgs(String value) {
+        processRuntimeArgs(LAUNCH_PUSH_NOTIFICATION_KEY, value);
+    }
+
+    private native static void processRuntimeArgs(String key, String value);
+}

--- a/modules/push-notifications/src/main/native/android/dalvik/PushFcmMessagingService.java
+++ b/modules/push-notifications/src/main/native/android/dalvik/PushFcmMessagingService.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2018, 2020, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.helloandroid;
+
+import android.app.Activity;
+import android.app.Application;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.net.Uri;
+import android.os.Build;
+import android.util.Log;
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+import java.util.UUID;
+
+public class PushFcmMessagingService extends FirebaseMessagingService {
+
+    public static final int REQUEST_CODE = 123456;
+    private static final String CHANNEL_ID = "gluon_attach_channel";
+    private static final String TAG = Util.TAG;
+    private static final boolean debug = Util.isDebug();
+
+    @Override
+    public void onMessageReceived(RemoteMessage remoteMessage) {
+        if (debug) {
+            Log.v(TAG, "Message received from " + remoteMessage.getFrom());
+        }
+
+        String id = "";
+        String body = "";
+        String title  = "";
+        boolean silent = false;
+        try {
+            id = remoteMessage.getData().get("id");
+            body = remoteMessage.getData().get("body");
+            title = remoteMessage.getData().get("title");
+            if (id == null) {
+                id = "";
+            } 
+            if (body == null) {
+                body = "";
+            } 
+            if (title == null) {
+                title = "";
+            }
+            silent = Boolean.parseBoolean(remoteMessage.getData().get("silent"));
+        } catch (Exception e) {
+            Log.e(TAG, "Error parsing remote message data: " + remoteMessage.getData() + ", " + e.getMessage());
+        }
+
+        if (silent) {
+            // invisible notification. Don't show, directly call into RAS
+            if (debug) {
+                Log.v(TAG, "Message will be processed through RAS");
+            }
+
+            String rasMessage = "{\"id\":\"" + id + "\", \"body\":\"" + body + "\", \"title\":\"" + title + "\"}";
+
+            // set the message as system property in case app was closed, so later on, 
+            // when resuming the app, RAS can handle it
+            System.setProperty(DalvikPushNotificationsService.LAUNCH_PUSH_NOTIFICATION_KEY, rasMessage);
+            // fire will work if the key is available, only when the app is running:
+            DalvikPushNotificationsService.sendRuntimeArgs(rasMessage);
+        } else {
+            if (debug) {
+                Log.v(TAG, "Message will be processed through a PushNotificationActivity");
+            }
+            sendNotification(id, title, body);
+        }
+    }
+ 
+    private void sendNotification(String id, String title, String body) {
+        NotificationManager notificationManager =
+                (NotificationManager) getSystemService(Activity.NOTIFICATION_SERVICE);
+        if (debug) {
+            Log.v(TAG, "Sending push notification with id: " + id + ", title: " + title + ", body: " + body);
+        }
+        notificationManager.notify(REQUEST_CODE, getNotification(title, body, 
+                id.isEmpty() ? UUID.randomUUID().toString() : id));
+    }
+    
+    private Notification getNotification(String title, String body, String id) {
+        final Application application = getApplication();
+        
+        Intent resultIntent = new Intent(application, PushNotificationActivity.class);
+        resultIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        resultIntent.setData(getData(id));
+        resultIntent.putExtra(PushNotificationActivity.MESSAGE, "{\"id\":\"" + id + "\", \"body\":\"" + body + "\", \"title\":\"" + title + "\"}");
+        resultIntent.putExtra(PushNotificationActivity.PACKAGE_NAME, application.getPackageName());
+        
+        PendingIntent resultPendingIntent = PendingIntent.getActivity(application, REQUEST_CODE, 
+                resultIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_ONE_SHOT);
+
+        android.app.Notification.Builder builder = new android.app.Notification.Builder(application);
+        if (title != null) {
+            builder.setContentTitle(title);
+        }
+        builder.setContentText(body);
+        builder.setSmallIcon(application.getApplicationInfo().icon);
+        builder.setPriority(android.app.Notification.PRIORITY_MAX); 
+        builder.setContentIntent(resultPendingIntent);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            builder.setCategory(android.app.Notification.CATEGORY_EVENT);
+            builder.setVisibility(android.app.Notification.VISIBILITY_PUBLIC);
+        }
+        builder.setDefaults(android.app.Notification.DEFAULT_VIBRATE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            //builder.setLargeIcon(BitmapFactory.decodeStream(notification.getImageInputStream()));
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            createChannelId();
+            builder.setChannelId(CHANNEL_ID);
+        }
+        builder.setAutoCancel(true);
+        return builder.build();
+    }
+    
+    // Provides unique Uri based on the id of the notification
+    private Uri getData(String id) {
+       return Uri.withAppendedPath(Uri.parse("charm://attach/Id/#"), id);
+    }
+
+    private void createChannelId() {
+        NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        final Application application = getApplication();
+        // The id of the channel
+        ApplicationInfo applicationInfo = application.getApplicationInfo();
+        int stringId = applicationInfo.labelRes;
+        // The user-visible name of the channel.
+        CharSequence name = stringId == 0 ? applicationInfo.nonLocalizedLabel.toString() : application.getString(stringId);
+        NotificationChannel mChannel = new NotificationChannel(CHANNEL_ID, name, NotificationManager.IMPORTANCE_HIGH);
+
+        // Configure the notification channel.
+        mChannel.setShowBadge(true);
+        mNotificationManager.createNotificationChannel(mChannel);
+    }
+}

--- a/modules/push-notifications/src/main/native/android/dalvik/PushInstanceIdService.java
+++ b/modules/push-notifications/src/main/native/android/dalvik/PushInstanceIdService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Gluon
+ * Copyright (c) 2018, 2020, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,13 +25,32 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-module com.gluonhq.attach.pushnotifications {
+package com.gluonhq.helloandroid;
 
-    requires transitive javafx.graphics;
-    requires java.json;
-    requires com.gluonhq.attach.util;
-    requires com.gluonhq.attach.runtimeargs;
+import android.util.Log;
+import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.FirebaseInstanceIdService;
 
-    exports com.gluonhq.attach.pushnotifications;
-    exports com.gluonhq.attach.pushnotifications.impl to com.gluonhq.attach.util;
+
+public class PushInstanceIdService extends FirebaseInstanceIdService {
+
+    private static final String TAG = Util.TAG;
+    private static final boolean debug = Util.isDebug();
+
+    /**
+     * Called if InstanceID token is updated. This may occur if the security of
+     * the previous token had been compromised. Note that this is also called
+     * when the InstanceID token is initially generated, so this is where
+     * you retrieve the token.
+     */
+    @Override
+    public void onTokenRefresh() {
+        if (debug) {
+            Log.v(TAG, "onTokenRefresh called, starting RegistrationIntent service.");
+        }
+        String refreshedToken = FirebaseInstanceId.getInstance().getToken();
+        sendToken(refreshedToken);
+    }
+
+    private native void sendToken(String token);
 }

--- a/modules/push-notifications/src/main/native/android/dalvik/PushNotificationActivity.java
+++ b/modules/push-notifications/src/main/native/android/dalvik/PushNotificationActivity.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2016, 2020, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.helloandroid;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.util.Log;
+
+public class PushNotificationActivity extends Activity {
+
+    private static final String TAG = Util.TAG;
+    private static final boolean debug = Util.isDebug();
+
+    public static final String MESSAGE = "message";
+    public static final String PACKAGE_NAME = "packageName";
+    private String message = "";
+    private String packageName;
+    
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        
+        message = getIntent().getStringExtra(MESSAGE);
+        packageName = getIntent().getStringExtra(PACKAGE_NAME);
+
+        final Activity activity = DalvikPushNotificationsService.getActivity();
+        if (activity != null && activity.getPackageName().equals(packageName)) {
+            // if we have an app running on front or in the background
+            if (debug) {
+                Log.v(TAG, "PushNotificationActivity - Fire MESSAGE: " + message);
+            }
+            DalvikPushNotificationsService.sendRuntimeArgs(message);
+        } else {
+            // we can open the application otherwise
+            if (!openApp(this, packageName)) {
+                Log.e(TAG, "PushNotificationActivity - Error opening app: " + packageName);
+            }
+        }
+        finish();
+    }
+
+    public boolean openApp(Context context, String packageName) {
+        PackageManager manager = context.getPackageManager();
+        try {
+            Intent intent = manager.getLaunchIntentForPackage(packageName);
+            if (intent == null) {
+                Log.e(TAG, "PushNotificationActivity :: App error in package: " + packageName);
+                return false;
+            }
+            Log.v(TAG, "PushNotificationActivity - Set property " + DalvikPushNotificationsService.LAUNCH_PUSH_NOTIFICATION_KEY + " with value: " + message);
+            System.setProperty(DalvikPushNotificationsService.LAUNCH_PUSH_NOTIFICATION_KEY, message);
+            intent.addCategory(Intent.CATEGORY_LAUNCHER);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            startActivity(intent);
+            return true;
+        } catch (Exception e) {
+            Log.e(TAG, "PushNotificationActivity :: App error: " + e.getMessage());
+            return false;
+        }
+    }
+
+
+}
+
+

--- a/modules/push-notifications/src/main/native/android/dalvik/PushNotificationJobService.java
+++ b/modules/push-notifications/src/main/native/android/dalvik/PushNotificationJobService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Gluon
+ * Copyright (c) 2017, 2020, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,13 +25,27 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-module com.gluonhq.attach.pushnotifications {
+package com.gluonhq.helloandroid;
 
-    requires transitive javafx.graphics;
-    requires java.json;
-    requires com.gluonhq.attach.util;
-    requires com.gluonhq.attach.runtimeargs;
+import android.app.job.JobParameters;
+import android.app.job.JobService;
+import android.util.Log;
 
-    exports com.gluonhq.attach.pushnotifications;
-    exports com.gluonhq.attach.pushnotifications.impl to com.gluonhq.attach.util;
+public class PushNotificationJobService extends JobService {
+
+    private static final String TAG = Util.TAG;
+
+    public static final int JOB_ID = 10;
+
+    @Override
+    public boolean onStartJob(JobParameters jobParameters) {
+        Log.v(TAG, "Gluon Attach PushNotification job has been triggered to start.");
+        return false;
+    }
+
+    @Override
+    public boolean onStopJob(JobParameters jobParameters) {
+        Log.v(TAG, "Gluon Attach PushNotification job has been triggered to stop.");
+        return true;
+    }
 }

--- a/modules/push-notifications/src/main/resources/META-INF/substrate/config/jniconfig-aarch64-android.json
+++ b/modules/push-notifications/src/main/resources/META-INF/substrate/config/jniconfig-aarch64-android.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name" : "com.gluonhq.attach.pushnotifications.impl.AndroidPushNotificationsService",
+    "methods":[
+      {"name":"<init>","parameterTypes":[]},
+      {"name":"setToken","parameterTypes":["java.lang.String"]},
+      {"name":"processRuntimeArgs","parameterTypes":["java.lang.String","java.lang.String"] }
+    ]
+  }
+]

--- a/modules/push-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-aarch64-android.json
+++ b/modules/push-notifications/src/main/resources/META-INF/substrate/config/reflectionconfig-aarch64-android.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name" : "com.gluonhq.attach.pushnotifications.impl.AndroidPushNotificationsService",
+    "methods":[{"name":"<init>","parameterTypes":[] }]
+  }
+]

--- a/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/AndroidManifest.xml
+++ b/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" package="com.gluonhq.helloandroid">
+    <uses-sdk android:minSdkVersion="21" />
+    <application>
+        <activity android:name='com.gluonhq.helloandroid.MainActivity'
+                  android:configChanges="orientation|keyboardHidden"
+                  android:launchMode="singleTop">
+            <intent-filter>
+                <category android:name='android.intent.category.LAUNCHER'/>
+                <action android:name='android.intent.action.MAIN'/>
+            </intent-filter>
+        </activity>
+        <activity android:name="com.gluonhq.helloandroid.NotificationActivity"
+            android:parentActivityName="com.gluonhq.helloandroid.MainActivity">
+            <meta-data android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.gluonhq.helloandroid.MainActivity"/>
+        </activity>
+        <receiver android:name="com.gluonhq.helloandroid.AlarmReceiver" />
+    </application>
+</manifest>

--- a/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/AndroidManifest.xml
+++ b/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/AndroidManifest.xml
@@ -19,7 +19,7 @@
                 android:permission="com.google.android.c2dm.permission.SEND" >
             <intent-filter>
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />
-                <category android:name="$packageName" />
+                <category android:name="${applicationId}" />
             </intent-filter>
         </receiver>
         <service android:name="com.gluonhq.helloandroid.PushFcmMessagingService">
@@ -44,8 +44,5 @@
             <meta-data android:name="android.support.PARENT_ACTIVITY"
                        android:value="com.gluonhq.helloandroid.MainActivity"/>
         </activity>
-
-        <meta-data android:name="com.google.android.gms.version"
-                   android:value="12451000"/>
     </application>
 </manifest>

--- a/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/AndroidManifest.xml
+++ b/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" package="com.gluonhq.helloandroid">
     <uses-sdk android:minSdkVersion="21" />
+    <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <application>
         <activity android:name='com.gluonhq.helloandroid.MainActivity'
                   android:configChanges="orientation|keyboardHidden"
@@ -10,11 +13,39 @@
                 <action android:name='android.intent.action.MAIN'/>
             </intent-filter>
         </activity>
-        <activity android:name="com.gluonhq.helloandroid.NotificationActivity"
-            android:parentActivityName="com.gluonhq.helloandroid.MainActivity">
+
+        <receiver android:name="com.google.firebase.iid.FirebaseInstanceIdReceiver"
+                android:exported="true"
+                android:permission="com.google.android.c2dm.permission.SEND" >
+            <intent-filter>
+                <action android:name="com.google.android.c2dm.intent.RECEIVE" />
+                <category android:name="$packageName" />
+            </intent-filter>
+        </receiver>
+        <service android:name="com.gluonhq.helloandroid.PushFcmMessagingService">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+        <service android:name="com.gluonhq.helloandroid.PushInstanceIdService">
+            <intent-filter>
+                <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />
+            </intent-filter>
+        </service>
+        <service android:name="com.google.firebase.components.ComponentDiscoveryService">
+            <meta-data android:name="com.google.firebase.components:com.google.firebase.iid.Registrar"
+                    android:value="com.google.firebase.components.ComponentRegistrar"/>
+        </service>
+        <service android:name="com.gluonhq.helloandroid.PushNotificationJobService"
+               android:permission="android.permission.BIND_JOB_SERVICE"
+               android:exported="true" />
+        <activity android:name="com.gluonhq.helloandroid.PushNotificationActivity"
+                android:parentActivityName="com.gluonhq.helloandroid.MainActivity">
             <meta-data android:name="android.support.PARENT_ACTIVITY"
-                android:value="com.gluonhq.helloandroid.MainActivity"/>
+                       android:value="com.gluonhq.helloandroid.MainActivity"/>
         </activity>
-        <receiver android:name="com.gluonhq.helloandroid.AlarmReceiver" />
+
+        <meta-data android:name="com.google.android.gms.version"
+                   android:value="12451000"/>
     </application>
 </manifest>

--- a/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/android-dependencies.txt
+++ b/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/android-dependencies.txt
@@ -1,0 +1,2 @@
+implementation 'com.google.gms:google-services:4.3.3'
+implementation 'com.google.firebase:firebase-messaging:17.3.0'

--- a/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/android-dependencies.txt
+++ b/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/android-dependencies.txt
@@ -1,2 +1,2 @@
 implementation 'com.google.gms:google-services:4.3.3'
-implementation 'com.google.firebase:firebase-messaging:17.3.0'
+implementation 'com.google.firebase:firebase-messaging:20.3.0'

--- a/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/build.gradle
+++ b/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/build.gradle
@@ -1,0 +1,25 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 29
+
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion 29
+    }
+
+    afterEvaluate {
+        generateDebugBuildConfig.enabled = false
+    }
+
+}
+
+repositories {
+    google()
+}
+
+dependencies {
+    provided fileTree(dir: '../libs', include: '*.jar')
+    implementation 'com.google.gms:google-services:4.3.3'
+    implementation 'com.google.firebase:firebase-messaging:20.3.0'
+}

--- a/modules/util/src/main/native/android/c/util.c
+++ b/modules/util/src/main/native/android/c/util.c
@@ -57,6 +57,7 @@ static jclass jMagnetometerServiceClass;
 static jclass jOrientationServiceClass;
 static jclass jPicturesServiceClass;
 static jclass jPositionServiceClass;
+static jclass jPushNotificationsServiceClass;
 static jclass jRuntimeArgsServiceClass;
 static jclass jSettingsServiceClass;
 static jclass jShareServiceClass;
@@ -183,6 +184,10 @@ jclass substrateGetPicturesServiceClass() {
 
 jclass substrateGetPositionServiceClass() {
     return GETREGISTERCLASS(jPositionServiceClass, "com/gluonhq/helloandroid/DalvikPositionService");
+}
+
+jclass substrateGetPushNotificationsServiceClass() {
+    return GETREGISTERCLASS(jPushNotificationsServiceClass, "com/gluonhq/helloandroid/DalvikPushNotificationsService");
 }
 
 jclass substrateGetRuntimeArgsServiceClass() {


### PR DESCRIPTION
Fixes #97 

`register(String)` is kept and marked as deprecated, as it will break Charm-CloudLink-Client.

Requires https://github.com/gluonhq/substrate/pull/807