### PR TITLE
Fix No fine (GPS) position on Android anymore

### DIFF
--- a/modules/position/src/main/native/android/dalvik/DalvikPositionService.java
+++ b/modules/position/src/main/native/android/dalvik/DalvikPositionService.java
@@ -73,14 +73,17 @@ public class DalvikPositionService implements LocationListener {
     private final boolean debug;
 
     public DalvikPositionService(Activity activity) {
-
         this.activityContext = activity;
         debug = Util.isDebug();
         if (debug) {
             Log.v(TAG, "Construct DalvikPositionService");
         }
-        boolean gpsEnabled = Util.verifyPermissions(Manifest.permission.ACCESS_COARSE_LOCATION) | // Both permissions require to be verified
-                Util.verifyPermissions(Manifest.permission.ACCESS_FINE_LOCATION);
+
+        // Verify both permissions
+        boolean coarseEnabled = Util.verifyPermissions(Manifest.permission.ACCESS_COARSE_LOCATION);
+        boolean fineEnabled = Util.verifyPermissions(Manifest.permission.ACCESS_FINE_LOCATION);
+        boolean gpsEnabled = coarseEnabled || fineEnabled;
+
         if (!gpsEnabled) {
             Log.v(TAG, "GPS disabled. ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION permissions are required");
         }

--- a/modules/position/src/main/native/android/dalvik/DalvikPositionService.java
+++ b/modules/position/src/main/native/android/dalvik/DalvikPositionService.java
@@ -79,7 +79,7 @@ public class DalvikPositionService implements LocationListener {
         if (debug) {
             Log.v(TAG, "Construct DalvikPositionService");
         }
-        boolean gpsEnabled = Util.verifyPermissions(Manifest.permission.ACCESS_COARSE_LOCATION) | // Don't use || here! 
+        boolean gpsEnabled = Util.verifyPermissions(Manifest.permission.ACCESS_COARSE_LOCATION) | // Both permissions require to be verified
                 Util.verifyPermissions(Manifest.permission.ACCESS_FINE_LOCATION);
         if (!gpsEnabled) {
             Log.v(TAG, "GPS disabled. ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION permissions are required");

--- a/modules/position/src/main/native/android/dalvik/DalvikPositionService.java
+++ b/modules/position/src/main/native/android/dalvik/DalvikPositionService.java
@@ -79,7 +79,7 @@ public class DalvikPositionService implements LocationListener {
         if (debug) {
             Log.v(TAG, "Construct DalvikPositionService");
         }
-        boolean gpsEnabled = Util.verifyPermissions(Manifest.permission.ACCESS_COARSE_LOCATION) || 
+        boolean gpsEnabled = Util.verifyPermissions(Manifest.permission.ACCESS_COARSE_LOCATION) | // Don't use || here! 
                 Util.verifyPermissions(Manifest.permission.ACCESS_FINE_LOCATION);
         if (!gpsEnabled) {
             Log.v(TAG, "GPS disabled. ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION permissions are required");


### PR DESCRIPTION
Fixes #222 No fine (GPS) position on Android anymore

Due to the || operator the check of the fine location was skipped here.