### PR TITLE
Sync released javadoc to /latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,10 @@ jobs:
         run: |
           TAG=${GITHUB_REF/refs\/tags\//}
           ./gradlew uploadJavadocToS3
+          # Update /latest with release version
+          aws s3 sync $AWS_S3_BUCKET_DOCS/attach/javadoc/$TAG/ $AWS_S3_BUCKET_DOCS/attach/javadoc/latest/ --acl public-read --region us-east-1
         env:
+          AWS_S3_BUCKET_DOCS: ${{ secrets.AWS_S3_BUCKET_DOCS }}
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
 


### PR DESCRIPTION
After releasing the latest javadoc, we sync its content to /latest