### PR TITLE
Update AWS env variables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,8 @@ jobs:
           aws s3 sync $AWS_S3_BUCKET_DOCS/attach/javadoc/$TAG/ $AWS_S3_BUCKET_DOCS/attach/javadoc/latest/ --acl public-read --region us-east-1
         env:
           AWS_S3_BUCKET_DOCS: ${{ secrets.AWS_S3_BUCKET_DOCS }}
-          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_KEY }}
 
       - name: Commit next development version
         if: steps.deploy.outputs.exit_code == 0


### PR DESCRIPTION
Current release workflow is failing with "fatal error: Unable to locate credentials" while trying to execute the AWS CLI command. This PR will fix it.