### PR TITLE
Install `gnu-sed` on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,12 @@ jobs:
       - name: Commit next development version
         if: steps.deploy.outputs.exit_code == 0
         run: |
+          brew install gnu-sed
           git config user.email "githubbot@gluonhq.com"
           git config user.name "Gluon Bot"
           TAG=${GITHUB_REF/refs\/tags\//}
           newVersion=${TAG%.*}.$((${TAG##*.} + 1)) # Update version by 1
-          sed -i -z "0,/version = $TAG/s//version = $newVersion-SNAPSHOT/" gradle.properties
+          gsed -i -z "0,/version = $TAG/s//version = $newVersion-SNAPSHOT/" gradle.properties
           git commit gradle.properties -m "Prepare development of $newVersion"
           git push https://gluon-bot:$PAT@github.com/$GITHUB_REPOSITORY HEAD:master
         env:


### PR DESCRIPTION
Mac has its own `sed` which doesn't have all gnu-sed features. This PR installs the GNU version of sed and use it via `gsed`