### PR TITLE
Adjust keyboard on Android and iOS

### DIFF
--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/AndroidKeyboardService.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/AndroidKeyboardService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Gluon
+ * Copyright (c) 2020, 2022, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -86,7 +86,7 @@ public class AndroidKeyboardService implements KeyboardService {
             if (debug) {
                 LOG.log(Level.INFO, String.format("Moving %s %.2f pixels", root, y));
             }
-            final TranslateTransition transition = new TranslateTransition(Duration.millis(100), root);
+            final TranslateTransition transition = new TranslateTransition(Duration.millis(50), root);
             transition.setFromY(root.getTranslateY());
             transition.setToY(y);
             transition.setInterpolator(Interpolator.EASE_OUT);

--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/IOSKeyboardService.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/IOSKeyboardService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Gluon
+ * Copyright (c) 2020, 2022, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -99,7 +99,7 @@ public class IOSKeyboardService implements KeyboardService {
             if (debug) {
                 LOG.log(Level.INFO, String.format("Moving %s %.2f pixels", root, y));
             }
-            final TranslateTransition transition = new TranslateTransition(Duration.millis(100), root);
+            final TranslateTransition transition = new TranslateTransition(Duration.millis(50), root);
             transition.setFromY(root.getTranslateY());
             transition.setToY(y);
             transition.setInterpolator(Interpolator.EASE_OUT);

--- a/modules/keyboard/src/main/native/android/c/keyboard.c
+++ b/modules/keyboard/src/main/native/android/c/keyboard.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Gluon
+ * Copyright (c) 2020, 2022, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,7 +32,7 @@ static jclass jAttachKeyboardClass;
 static jmethodID jAttach_notifyHeightMethod;
 
 void initKeyboard();
-jfloat density;
+static jfloat density;
 jfloat android_getDensity(JNIEnv *env);
 
 


### PR DESCRIPTION
This PR fixes #291

By reducing the transition time to move the JavaFX node once the keyboard height changes, the values are more accurate.

On Android we have to wait until the transition has finished to get the keyboard height, which now is measured against the new screen y value (retrieved after any orientation change). 