### PR TITLE
Get Home Indicator Height on iOS

### DIFF
--- a/modules/display/src/main/java/com/gluonhq/attach/display/DisplayService.java
+++ b/modules/display/src/main/java/com/gluonhq/attach/display/DisplayService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019 Gluon
+ * Copyright (c) 2016, 2022 Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -137,6 +137,12 @@ public interface DisplayService {
      * @since 3.3.0
      */
     float getScreenScale();
+
+    /**
+     * Returns the height of Home Indicator
+     * @return the height of Home Indicator
+     */
+    int getHomeIndicatorHeight();
 
     /**
      * Returns true if the device has a round screen

--- a/modules/display/src/main/java/com/gluonhq/attach/display/impl/AndroidDisplayService.java
+++ b/modules/display/src/main/java/com/gluonhq/attach/display/impl/AndroidDisplayService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020 Gluon
+ * Copyright (c) 2016, 2022 Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -101,6 +101,12 @@ public class AndroidDisplayService implements DisplayService {
             LOG.log(Level.INFO, "Screen scale: " + scale);
         }
         return scale;
+    }
+
+    @Override
+    public int getHomeIndicatorHeight() {
+        // Not Implemented Yet
+        return 0;
     }
 
     @Override

--- a/modules/display/src/main/java/com/gluonhq/attach/display/impl/DesktopDisplayService.java
+++ b/modules/display/src/main/java/com/gluonhq/attach/display/impl/DesktopDisplayService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019 Gluon
+ * Copyright (c) 2016, 2022 Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -84,6 +84,11 @@ public class DesktopDisplayService implements DisplayService {
     @Override
     public float getScreenScale() {
         return (float) Math.min(Screen.getPrimary().getOutputScaleX(), Screen.getPrimary().getOutputScaleY());
+    }
+
+    @Override
+    public int getHomeIndicatorHeight() {
+        return 0;
     }
 
     @Override

--- a/modules/display/src/main/java/com/gluonhq/attach/display/impl/IOSDisplayService.java
+++ b/modules/display/src/main/java/com/gluonhq/attach/display/impl/IOSDisplayService.java
@@ -38,7 +38,7 @@ import javafx.geometry.Dimension2D;
 public class IOSDisplayService implements DisplayService {
 
     static {
-        System.loadLibrary("Display");
+        Platform.runLater(()->System.loadLibrary("Display"));
         initDisplay();
     }
 

--- a/modules/display/src/main/java/com/gluonhq/attach/display/impl/IOSDisplayService.java
+++ b/modules/display/src/main/java/com/gluonhq/attach/display/impl/IOSDisplayService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019 Gluon
+ * Copyright (c) 2016, 2022 Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -81,6 +81,11 @@ public class IOSDisplayService implements DisplayService {
     }
 
     @Override
+    public int getHomeIndicatorHeight() {
+       return getSafeAreaInsets()[1];
+    }
+
+    @Override
     public float getScreenScale() {
         return screenScale();
     }
@@ -100,6 +105,11 @@ public class IOSDisplayService implements DisplayService {
         return notch.getReadOnlyProperty();
     }
 
+    private int [] getSafeAreaInsets() {
+       return safeAreaInsets();
+    }
+
+
     // native
     private static native void initDisplay();
 
@@ -108,6 +118,7 @@ public class IOSDisplayService implements DisplayService {
     private native static double[] screenBounds();
     private native static float screenScale();
     private native static boolean isNotchFound();
+    private native static int[] safeAreaInsets();
 
     private static native void startObserver();
     private static native void stopObserver();

--- a/modules/display/src/main/native/ios/Display.m
+++ b/modules/display/src/main/native/ios/Display.m
@@ -273,4 +273,33 @@ NSString * GetDeviceModel(void)
     sendNotch();
 }
 
+JNIEXPORT jintArray JNICALL Java_com_gluonhq_attach_display_impl_IOSDisplayService_safeAreaInsets
+(JNIEnv *env, jclass jClass)
+{
+    jintArray output = (*env)->NewIntArray(env, 2);
+    if (output == NULL) {
+        return NULL;
+    }
+
+    if (@available(iOS 11.0, *)) {
+        UIWindow* window = [UIApplication sharedApplication].keyWindow;
+        if(!window)
+        {
+           AttachLog(@"key window was nil");
+           return NULL;
+        }
+        CGFloat topPadding = window.safeAreaInsets.top;
+        CGFloat bottomPadding = window.safeAreaInsets.bottom;
+
+        jint res[] = {topPadding, bottomPadding};
+        (*env)->SetIntArrayRegion(env, output, 0, 2, res);
+        return output;
+
+    }
+    jint res[]={0,0};
+    (*env)->SetIntArrayRegion(env, output, 0, 2, res);
+    return output;
+}
+
+
 @end


### PR DESCRIPTION
Fixes #245
Needs implementation for Android.
Always return "0" for Desktops.