### PR TITLE
prevent NPE in Util

### DIFF
--- a/modules/util/src/main/native/android/dalvik/Util.java
+++ b/modules/util/src/main/native/android/dalvik/Util.java
@@ -87,6 +87,9 @@ public class Util {
 
             @Override
             public void run() {
+                if (Util.activity == null) {
+                    return;
+                }
                 new Handler(Util.activity.getMainLooper()).postDelayed(new Runnable() {
 
                     @Override


### PR DESCRIPTION
This is not safe:

```
 private static void syncClipboardFromOS() {
        if (Util.activity == null) {
             return;
        }
        Util.activity.runOnUiThread(new Runnable() {

            @Override
            public void run() {
                new Handler(Util.activity.getMainLooper()).postDelayed(new Runnable() {
```

because Util can be called from several services. While the first null check is correct, in #383 StorageService asks for some permissions, and then it nullifies `Util.activity`  before the handler is created, causing a NPE in `Util.activity.getMainLooper()`.

Therefore, a second null check is required.