### PR TITLE
Fixed some issues and improved performance of AndroidAudioService

### DIFF
--- a/modules/audio/src/main/java/com/gluonhq/attach/audio/impl/AndroidAudioService.java
+++ b/modules/audio/src/main/java/com/gluonhq/attach/audio/impl/AndroidAudioService.java
@@ -30,10 +30,6 @@ package com.gluonhq.attach.audio.impl;
 import com.gluonhq.attach.audio.Audio;
 import com.gluonhq.attach.audio.AudioService;
 import com.gluonhq.attach.storage.StorageService;
-import javafx.collections.ListChangeListener;
-import javafx.scene.input.KeyEvent;
-import javafx.stage.Stage;
-import javafx.stage.Window;
 
 import java.io.File;
 import java.io.InputStream;
@@ -45,7 +41,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.logging.Logger;
-import java.util.List;
 
 /**
  * @author Almas Baimagambetov (almaslvl@gmail.com)
@@ -56,37 +51,6 @@ public class AndroidAudioService implements AudioService {
 
     static {
         System.loadLibrary("audio");
-        // Installing an event filter on all present and future stages to dispatch the volume key events
-        installVolumeKeysFilterOnStages(Window.getWindows());
-        Window.getWindows().addListener((ListChangeListener<Window>) change -> {
-            while (change.next()) {
-                if (change.wasAdded()) {
-                    installVolumeKeysFilterOnStages(change.getAddedSubList());
-                }
-            }
-        });
-    }
-
-    private static void installVolumeKeysFilterOnStages(List<? extends Window> windows) {
-        // We add an event filter on all stages that intercepts when a volume key is pressed, and dispatches this to the native service
-        windows.stream().filter(Stage.class::isInstance).map(Stage.class::cast).forEach(stage ->
-                stage.addEventFilter(KeyEvent.KEY_PRESSED, e -> {
-                    switch (e.getCode()) {
-                        case VOLUME_UP:
-                            onVolumeUpKeyPressed();
-                            e.consume();
-                            break;
-                        case VOLUME_DOWN:
-                            onVolumeDownKeyPressed();
-                            e.consume();
-                            break;
-                        case MUTE:
-                            onVolumeMuteKeyPressed();
-                            e.consume();
-                            break;
-                    }
-                })
-        );
     }
 
     private File privateStorage;
@@ -244,10 +208,6 @@ public class AndroidAudioService implements AudioService {
         }
     }
 
-    private native static void onVolumeUpKeyPressed();
-    private native static void onVolumeDownKeyPressed();
-    private native static void onVolumeMuteKeyPressed();
-    // native
     private native static int loadSoundImpl(String fullName);
     private native static int loadMusicImpl(String fullName);
 

--- a/modules/audio/src/main/java/com/gluonhq/attach/audio/impl/AndroidAudioService.java
+++ b/modules/audio/src/main/java/com/gluonhq/attach/audio/impl/AndroidAudioService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Gluon
+ * Copyright (c) 2020, 2023, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,6 +30,10 @@ package com.gluonhq.attach.audio.impl;
 import com.gluonhq.attach.audio.Audio;
 import com.gluonhq.attach.audio.AudioService;
 import com.gluonhq.attach.storage.StorageService;
+import javafx.collections.ListChangeListener;
+import javafx.scene.input.KeyEvent;
+import javafx.stage.Stage;
+import javafx.stage.Window;
 
 import java.io.File;
 import java.io.InputStream;
@@ -41,6 +45,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.logging.Logger;
+import java.util.List;
 
 /**
  * @author Almas Baimagambetov (almaslvl@gmail.com)
@@ -51,6 +56,37 @@ public class AndroidAudioService implements AudioService {
 
     static {
         System.loadLibrary("audio");
+        // Installing an event filter on all present and future stages to dispatch the volume key events
+        installVolumeKeysFilterOnStages(Window.getWindows());
+        Window.getWindows().addListener((ListChangeListener<Window>) change -> {
+            while (change.next()) {
+                if (change.wasAdded()) {
+                    installVolumeKeysFilterOnStages(change.getAddedSubList());
+                }
+            }
+        });
+    }
+
+    private static void installVolumeKeysFilterOnStages(List<? extends Window> windows) {
+        // We add an event filter on all stages that intercepts when a volume key is pressed, and dispatches this to the native service
+        windows.stream().filter(Stage.class::isInstance).map(Stage.class::cast).forEach(stage ->
+                stage.addEventFilter(KeyEvent.KEY_PRESSED, e -> {
+                    switch (e.getCode()) {
+                        case VOLUME_UP:
+                            onVolumeUpKeyPressed();
+                            e.consume();
+                            break;
+                        case VOLUME_DOWN:
+                            onVolumeDownKeyPressed();
+                            e.consume();
+                            break;
+                        case MUTE:
+                            onVolumeMuteKeyPressed();
+                            e.consume();
+                            break;
+                    }
+                })
+        );
     }
 
     private File privateStorage;
@@ -208,6 +244,9 @@ public class AndroidAudioService implements AudioService {
         }
     }
 
+    private native static void onVolumeUpKeyPressed();
+    private native static void onVolumeDownKeyPressed();
+    private native static void onVolumeMuteKeyPressed();
     // native
     private native static int loadSoundImpl(String fullName);
     private native static int loadMusicImpl(String fullName);

--- a/modules/audio/src/main/java/com/gluonhq/attach/audio/impl/AndroidAudioService.java
+++ b/modules/audio/src/main/java/com/gluonhq/attach/audio/impl/AndroidAudioService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Gluon
+ * Copyright (c) 2020, 2023, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/audio/src/main/java/module-info.java
+++ b/modules/audio/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Gluon
+ * Copyright (c) 2020, 2023, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,6 +26,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 module com.gluonhq.attach.audio {
+
+    requires javafx.graphics;
 
     requires com.gluonhq.attach.storage;
     requires com.gluonhq.attach.util;

--- a/modules/audio/src/main/java/module-info.java
+++ b/modules/audio/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Gluon
+ * Copyright (c) 2020, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 module com.gluonhq.attach.audio {
-
-    requires javafx.graphics;
 
     requires com.gluonhq.attach.storage;
     requires com.gluonhq.attach.util;

--- a/modules/audio/src/main/native/android/c/audio.c
+++ b/modules/audio/src/main/native/android/c/audio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Gluon
+ * Copyright (c) 2020, 2023, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/audio/src/main/native/android/c/audio.c
+++ b/modules/audio/src/main/native/android/c/audio.c
@@ -29,9 +29,6 @@
 
 static jclass jAudioServiceClass;
 static jobject jDalvikAudioService;
-static jmethodID jAudioServiceOnVolumeUpKeyPressMethod;
-static jmethodID jAudioServiceOnVolumeDownKeyPressMethod;
-static jmethodID jAudioServiceOnVolumeMuteKeyPressMethod;
 static jmethodID jAudioServiceLoadSoundMethod;
 static jmethodID jAudioServiceLoadMusicMethod;
 static jmethodID jAudioServiceSetLoopingMethod;
@@ -45,10 +42,6 @@ static void initializeAudioDalvikHandles() {
     jAudioServiceClass = GET_REGISTER_DALVIK_CLASS(jAudioServiceClass, "com/gluonhq/helloandroid/DalvikAudioService");
     ATTACH_DALVIK();
     jmethodID jAudioServiceInitMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "<init>", "(Landroid/app/Activity;)V");
-
-    jAudioServiceOnVolumeUpKeyPressMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "onVolumeUpKeyPressed", "()V");
-    jAudioServiceOnVolumeDownKeyPressMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "onVolumeDownKeyPressed", "()V");
-    jAudioServiceOnVolumeMuteKeyPressMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "onVolumeMuteKeyPressed", "()V");
 
     jAudioServiceLoadSoundMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "loadSoundImpl", "(Ljava/lang/String;)I");
     jAudioServiceLoadMusicMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "loadMusicImpl", "(Ljava/lang/String;)I");
@@ -88,30 +81,6 @@ JNI_OnLoad_audio(JavaVM *vm, void *reserved)
 }
 
 // from Java to Android
-
-JNIEXPORT void JNICALL Java_com_gluonhq_attach_audio_impl_AndroidAudioService_onVolumeUpKeyPressed
-(JNIEnv *env, jclass jClass)
-{
-    ATTACH_DALVIK();
-    (*dalvikEnv)->CallVoidMethod(dalvikEnv, jDalvikAudioService, jAudioServiceOnVolumeUpKeyPressMethod);
-    DETACH_DALVIK();
-}
-
-JNIEXPORT void JNICALL Java_com_gluonhq_attach_audio_impl_AndroidAudioService_onVolumeDownKeyPressed
-(JNIEnv *env, jclass jClass)
-{
-    ATTACH_DALVIK();
-    (*dalvikEnv)->CallVoidMethod(dalvikEnv, jDalvikAudioService, jAudioServiceOnVolumeDownKeyPressMethod);
-    DETACH_DALVIK();
-}
-
-JNIEXPORT void JNICALL Java_com_gluonhq_attach_audio_impl_AndroidAudioService_onVolumeMuteKeyPressed
-(JNIEnv *env, jclass jClass)
-{
-    ATTACH_DALVIK();
-    (*dalvikEnv)->CallVoidMethod(dalvikEnv, jDalvikAudioService, jAudioServiceOnVolumeMuteKeyPressMethod);
-    DETACH_DALVIK();
-}
 
 JNIEXPORT jint JNICALL Java_com_gluonhq_attach_audio_impl_AndroidAudioService_loadSoundImpl
 (JNIEnv *env, jclass jClass, jstring jURL)

--- a/modules/audio/src/main/native/android/c/audio.c
+++ b/modules/audio/src/main/native/android/c/audio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Gluon
+ * Copyright (c) 2020, 2023, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,6 +29,9 @@
 
 static jclass jAudioServiceClass;
 static jobject jDalvikAudioService;
+static jmethodID jAudioServiceOnVolumeUpKeyPressMethod;
+static jmethodID jAudioServiceOnVolumeDownKeyPressMethod;
+static jmethodID jAudioServiceOnVolumeMuteKeyPressMethod;
 static jmethodID jAudioServiceLoadSoundMethod;
 static jmethodID jAudioServiceLoadMusicMethod;
 static jmethodID jAudioServiceSetLoopingMethod;
@@ -42,6 +45,10 @@ static void initializeAudioDalvikHandles() {
     jAudioServiceClass = GET_REGISTER_DALVIK_CLASS(jAudioServiceClass, "com/gluonhq/helloandroid/DalvikAudioService");
     ATTACH_DALVIK();
     jmethodID jAudioServiceInitMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "<init>", "(Landroid/app/Activity;)V");
+
+    jAudioServiceOnVolumeUpKeyPressMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "onVolumeUpKeyPressed", "()V");
+    jAudioServiceOnVolumeDownKeyPressMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "onVolumeDownKeyPressed", "()V");
+    jAudioServiceOnVolumeMuteKeyPressMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "onVolumeMuteKeyPressed", "()V");
 
     jAudioServiceLoadSoundMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "loadSoundImpl", "(Ljava/lang/String;)I");
     jAudioServiceLoadMusicMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "loadMusicImpl", "(Ljava/lang/String;)I");
@@ -81,6 +88,30 @@ JNI_OnLoad_audio(JavaVM *vm, void *reserved)
 }
 
 // from Java to Android
+
+JNIEXPORT void JNICALL Java_com_gluonhq_attach_audio_impl_AndroidAudioService_onVolumeUpKeyPressed
+(JNIEnv *env, jclass jClass)
+{
+    ATTACH_DALVIK();
+    (*dalvikEnv)->CallVoidMethod(dalvikEnv, jDalvikAudioService, jAudioServiceOnVolumeUpKeyPressMethod);
+    DETACH_DALVIK();
+}
+
+JNIEXPORT void JNICALL Java_com_gluonhq_attach_audio_impl_AndroidAudioService_onVolumeDownKeyPressed
+(JNIEnv *env, jclass jClass)
+{
+    ATTACH_DALVIK();
+    (*dalvikEnv)->CallVoidMethod(dalvikEnv, jDalvikAudioService, jAudioServiceOnVolumeDownKeyPressMethod);
+    DETACH_DALVIK();
+}
+
+JNIEXPORT void JNICALL Java_com_gluonhq_attach_audio_impl_AndroidAudioService_onVolumeMuteKeyPressed
+(JNIEnv *env, jclass jClass)
+{
+    ATTACH_DALVIK();
+    (*dalvikEnv)->CallVoidMethod(dalvikEnv, jDalvikAudioService, jAudioServiceOnVolumeMuteKeyPressMethod);
+    DETACH_DALVIK();
+}
 
 JNIEXPORT jint JNICALL Java_com_gluonhq_attach_audio_impl_AndroidAudioService_loadSoundImpl
 (JNIEnv *env, jclass jClass, jstring jURL)

--- a/modules/audio/src/main/native/android/c/audio.c
+++ b/modules/audio/src/main/native/android/c/audio.c
@@ -41,7 +41,7 @@ static jmethodID jAudioServiceDisposeMethod;
 static void initializeAudioDalvikHandles() {
     jAudioServiceClass = GET_REGISTER_DALVIK_CLASS(jAudioServiceClass, "com/gluonhq/helloandroid/DalvikAudioService");
     ATTACH_DALVIK();
-    jmethodID jAudioServiceInitMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "<init>", "()V");
+    jmethodID jAudioServiceInitMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "<init>", "(Landroid/app/Activity;)V");
 
     jAudioServiceLoadSoundMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "loadSoundImpl", "(Ljava/lang/String;)I");
     jAudioServiceLoadMusicMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "loadMusicImpl", "(Ljava/lang/String;)I");
@@ -53,7 +53,8 @@ static void initializeAudioDalvikHandles() {
     jAudioServiceStopMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "stop", "(I)V");
     jAudioServiceDisposeMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jAudioServiceClass, "dispose", "(I)V");
 
-    jobject jObj = (*dalvikEnv)->NewObject(dalvikEnv, jAudioServiceClass, jAudioServiceInitMethod);
+    jobject jActivity = substrateGetActivity();
+    jobject jObj = (*dalvikEnv)->NewObject(dalvikEnv, jAudioServiceClass, jAudioServiceInitMethod, jActivity);
     jDalvikAudioService = (*dalvikEnv)->NewGlobalRef(dalvikEnv, jObj);
 
     DETACH_DALVIK();

--- a/modules/audio/src/main/native/android/dalvik/DalvikAudioService.java
+++ b/modules/audio/src/main/native/android/dalvik/DalvikAudioService.java
@@ -27,6 +27,7 @@
  */
 package com.gluonhq.helloandroid;
 
+import android.app.Activity;
 import android.media.AudioAttributes;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
@@ -42,8 +43,8 @@ public class DalvikAudioService {
 
     private SoundPool pool = null;
 
-    public DalvikAudioService() {
-
+    public DalvikAudioService(Activity activity) {
+        activity.setVolumeControlStream(AudioManager.STREAM_MUSIC);
     }
 
     /**

--- a/modules/audio/src/main/native/android/dalvik/DalvikAudioService.java
+++ b/modules/audio/src/main/native/android/dalvik/DalvikAudioService.java
@@ -109,7 +109,7 @@ public class DalvikAudioService {
         return new SoundPool.Builder()
                 .setAudioAttributes(audioAttributes)
                 // this is arbitrary, but it should be a reasonable amount
-                .setMaxStreams(5)
+                .setMaxStreams(20)
                 .build();
     }
 

--- a/modules/audio/src/main/native/android/dalvik/DalvikAudioService.java
+++ b/modules/audio/src/main/native/android/dalvik/DalvikAudioService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Gluon
+ * Copyright (c) 2020, 2023, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/modules/audio/src/main/native/android/dalvik/DalvikAudioService.java
+++ b/modules/audio/src/main/native/android/dalvik/DalvikAudioService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Gluon
+ * Copyright (c) 2020, 2023, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,6 +28,7 @@
 package com.gluonhq.helloandroid;
 
 import android.app.Activity;
+import android.content.Context;
 import android.media.AudioAttributes;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
@@ -39,12 +40,43 @@ import java.util.Arrays;
 
 public class DalvikAudioService {
 
+    private final AudioManager audioManager;
+    private int preMuteVolume;
+
     private DalvikAudio[] cache = new DalvikAudio[10];
 
     private SoundPool pool = null;
 
     public DalvikAudioService(Activity activity) {
         activity.setVolumeControlStream(AudioManager.STREAM_MUSIC);
+        audioManager = (AudioManager) activity.getSystemService(Context.AUDIO_SERVICE);
+    }
+
+    private void onVolumeUpKeyPressed() {
+        int currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC);
+        int maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+        audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
+                (currentVolume + 1) <= maxVolume ? AudioManager.ADJUST_RAISE : AudioManager.ADJUST_SAME, AudioManager.FLAG_SHOW_UI);
+
+    }
+
+    private void onVolumeDownKeyPressed() {
+        int currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC);
+        int maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
+        audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
+                (currentVolume - 1) >= 0 ? AudioManager.ADJUST_LOWER : AudioManager.ADJUST_SAME, AudioManager.FLAG_SHOW_UI);
+    }
+
+    private void onVolumeMuteKeyPressed() {
+        int currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC);
+        if (currentVolume > 0) {
+            preMuteVolume = currentVolume;
+            audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_SAME,
+                    AudioManager.FLAG_REMOVE_SOUND_AND_VIBRATE | AudioManager.FLAG_SHOW_UI);
+        } else {
+            preMuteVolume = 0;
+            audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, preMuteVolume, AudioManager.FLAG_SHOW_UI);
+        }
     }
 
     /**

--- a/modules/audio/src/main/native/android/dalvik/DalvikAudioService.java
+++ b/modules/audio/src/main/native/android/dalvik/DalvikAudioService.java
@@ -40,43 +40,11 @@ import java.util.Arrays;
 
 public class DalvikAudioService {
 
-    private final AudioManager audioManager;
-    private int preMuteVolume;
-
     private DalvikAudio[] cache = new DalvikAudio[10];
-
     private SoundPool pool = null;
 
     public DalvikAudioService(Activity activity) {
         activity.setVolumeControlStream(AudioManager.STREAM_MUSIC);
-        audioManager = (AudioManager) activity.getSystemService(Context.AUDIO_SERVICE);
-    }
-
-    private void onVolumeUpKeyPressed() {
-        int currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC);
-        int maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
-        audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
-                (currentVolume + 1) <= maxVolume ? AudioManager.ADJUST_RAISE : AudioManager.ADJUST_SAME, AudioManager.FLAG_SHOW_UI);
-
-    }
-
-    private void onVolumeDownKeyPressed() {
-        int currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC);
-        int maxVolume = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC);
-        audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC,
-                (currentVolume - 1) >= 0 ? AudioManager.ADJUST_LOWER : AudioManager.ADJUST_SAME, AudioManager.FLAG_SHOW_UI);
-    }
-
-    private void onVolumeMuteKeyPressed() {
-        int currentVolume = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC);
-        if (currentVolume > 0) {
-            preMuteVolume = currentVolume;
-            audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, AudioManager.ADJUST_SAME,
-                    AudioManager.FLAG_REMOVE_SOUND_AND_VIBRATE | AudioManager.FLAG_SHOW_UI);
-        } else {
-            preMuteVolume = 0;
-            audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, preMuteVolume, AudioManager.FLAG_SHOW_UI);
-        }
     }
 
     /**


### PR DESCRIPTION
hi,

I'm making this PR to propose the following changes to the AndroidAudioService:
- Bug fixes:
    - The up & down volume buttons were not showing/working when using the AndroidAudioService
    - I faced this little problem: calling pause() or stop() before play() on a music wasn't playing it (it's actually the behaviour of the Android API, but it's better to adopt an identical behaviour for all platforms. With this fix, AndroidAudioService will behaves like on iOS - which behaves like the JavaFX API)
- Performance improvements:
    - Native calls are made in a separate thread (like in IOSAudioService)
    - Subsequent calls to play() on sounds are skipped when too close (like in IOSAudioService)
    - I increased the SoundPool maxStreams setting from 5 to 20 (5 was too small because this pool is global to all sounds)
 
I contacted Almas but he said he didn't have time to review these changes, and he was happy for me to submit the PR.

Regarding the performance improvements, they might not be noticeable in most games, but I'm working on a new version of SpaceFX with an increased number of ennemies, and I promise these changes make a noticeable difference.

Like I said, I plan to publish the WebFX demos on the Google Play & App Stores to show live examples of JavaFX apps compiled by Gluon. I'm working in particular on this new version of SpaceFX as an example of how performant the native apps compiled with Gluon can be (this is in this context that I'm making these changes). Let me know if you want access to this new version of SpaceFX to test this PR (works great now on iPads and Android tablets).