### PR TITLE
Use GITHUB_TOKEN instead of PAT in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,4 +70,4 @@ jobs:
           git commit gradle.properties -m "Prepare development of $newVersion"
           git push https://gluon-bot:$PAT@github.com/$GITHUB_REPOSITORY HEAD:master
         env:
-          PAT: ${{ secrets.PAT }}
+          PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #349 