### PR TITLE
add bt scan permission to manifest and init routine of DalvikBleService

### DIFF
--- a/modules/ble/src/main/native/android/dalvik/DalvikBleService.java
+++ b/modules/ble/src/main/native/android/dalvik/DalvikBleService.java
@@ -90,6 +90,12 @@ public class DalvikBleService  {
         if (!fineloc) {
             Log.v(TAG, "No permission to get fine location");
         }
+        boolean scanperm = Util.verifyPermissions(new String[]{"android.permission.BLUETOOTH_SCAN"});
+        if (!scanperm) {
+           Log.v("GluonAttach", "DalvikBle No permission to SCAN BLUETOOH");
+        }
+
+        
         final BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
         if (!adapter.isEnabled()) {
             Log.v(TAG, "DalvikBle, init, adapter not enabled");

--- a/modules/ble/src/main/resources/META-INF/substrate/dalvik/AndroidManifest.xml
+++ b/modules/ble/src/main/resources/META-INF/substrate/dalvik/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-sdk android:minSdkVersion="21" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />    
 </manifest>
 


### PR DESCRIPTION
Android API level 3 has a new permission for BLE peripherals as described  [here](https://developer.android.com/guide/topics/connectivity/bluetooth/permissions).