### PR TITLE
Add broadcaster receiver to process push notifications

### DIFF
--- a/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/PushNotificationsService.java
+++ b/modules/push-notifications/src/main/java/com/gluonhq/attach/pushnotifications/PushNotificationsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Gluon
+ * Copyright (c) 2016, 2024, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -89,6 +89,13 @@ import java.util.Optional;
  *            <meta-data android:name="android.support.PARENT_ACTIVITY"
  *                       android:value="com.gluonhq.helloandroid.MainActivity"/>
  *      </activity>
+ *      <receiver android:name="com.gluonhq.helloandroid.FirebaseBroadcastReceiver"
+ *                android:exported="true"
+ *                android:permission="com.google.android.c2dm.permission.SEND">
+ *             <intent-filter>
+ *                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />
+ *             </intent-filter>
+ *      </receiver>
  *    </application>
  *  </manifest>}</pre>
  *

--- a/modules/push-notifications/src/main/native/android/dalvik/DalvikPushNotificationsService.java
+++ b/modules/push-notifications/src/main/native/android/dalvik/DalvikPushNotificationsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Gluon
+ * Copyright (c) 2016, 2024, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,6 +48,7 @@ public class DalvikPushNotificationsService {
     private static final boolean debug = Util.isDebug();
 
     private static Activity activity;
+    private static boolean active;
     static int badgeNumber = 0;
 
     public DalvikPushNotificationsService(Activity activity) {
@@ -59,10 +60,33 @@ public class DalvikPushNotificationsService {
                 Log.v(TAG, "Post notifications disabled. POST_NOTIFICATIONS permission is required");
             }
         }
+
+        active = true;
+        Util.setLifecycleEventHandler(new LifecycleEventHandler() {
+            @Override
+            public void lifecycleEvent(String event) {
+                if (event != null && !event.isEmpty()) {
+                    switch (event) {
+                        case "pause":
+                            active = false;
+                            break;
+                        case "resume":
+                            active = true;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+        });
     }
 
     static Activity getActivity() {
         return activity;
+    }
+
+    static boolean isActive() {
+        return active;
     }
 
     public String getPackageName() {

--- a/modules/push-notifications/src/main/native/android/dalvik/FirebaseBroadcastReceiver.java
+++ b/modules/push-notifications/src/main/native/android/dalvik/FirebaseBroadcastReceiver.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.helloandroid;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class FirebaseBroadcastReceiver extends BroadcastReceiver {
+
+    private static final String TAG = Util.TAG;
+    private static final boolean debug = Util.isDebug();
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent == null || intent.getExtras() == null || !"com.google.android.c2dm.intent.RECEIVE".equals(intent.getAction())) {
+            return;
+        }
+        if (debug) {
+            Log.v(TAG, "FirebaseBroadcastReceiver has intent");
+        }
+        String id = setValueOr(intent.getStringExtra("id"), intent.getStringExtra("google.message_id"));
+        String title = setValueOr(intent.getStringExtra("title"), intent.getStringExtra("gcm.notification.title"));
+        String body = setValueOr(intent.getStringExtra("body"), intent.getStringExtra("gcm.notification.body"));
+        String silent = setValueOr(intent.getStringExtra("silent"), "false");
+
+        HashMap<String, String> payload = new HashMap<>();
+        payload.put("id", id);
+        payload.put("title", title);
+        payload.put("body", body);
+        payload.put("silent", silent);
+
+        String rasMessage = jsonPrintMap(payload);
+
+
+        if (DalvikPushNotificationsService.getActivity() != null) {
+            if (!DalvikPushNotificationsService.isActive()) {
+                // if we have an app running in the background
+                if (debug) {
+                    Log.v(TAG, "FirebaseBroadcastReceiver: App in background, processing notification through RAS");
+                }
+                System.setProperty(DalvikPushNotificationsService.LAUNCH_PUSH_NOTIFICATION_KEY, rasMessage);
+                DalvikPushNotificationsService.sendRuntimeArgs(rasMessage);
+            } else {
+                // app is active, PushFcmMessagingService process and creates notification in PushNotificationActivity
+            }
+        } else {
+            if (debug) {
+                Log.v(TAG, "FirebaseBroadcastReceiver: App closed, Message will be processed through RAS");
+            }
+            // set the message as system property as app is closed, so later on,
+            // when starting the app after tapping the notification, RAS can handle it
+            System.setProperty(DalvikPushNotificationsService.LAUNCH_PUSH_NOTIFICATION_KEY, rasMessage);
+        }
+    }
+
+    private String setValueOr(String first, String second) {
+        return (first == null || first.isEmpty()) ? second : first;
+    }
+
+    private String jsonPrintMap(HashMap<String, String> map) {
+        String json = "";
+        for (Entry<String, String> entry : map.entrySet()) {
+            if (!json.isEmpty()) {
+                json += ",";
+            }
+            json += "\"" + entry.getKey() + "\":\"" + entry.getValue() + "\"";
+        }
+        return "{" + json + "}";
+    }
+}

--- a/modules/push-notifications/src/main/native/android/dalvik/PushFcmMessagingService.java
+++ b/modules/push-notifications/src/main/native/android/dalvik/PushFcmMessagingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Gluon
+ * Copyright (c) 2018, 2024, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -57,6 +57,13 @@ public class PushFcmMessagingService extends FirebaseMessagingService {
     private static final String TAG = Util.TAG;
     private static final boolean debug = Util.isDebug();
 
+    /**
+     * This is only called when app is in foreground. It needs data payload
+     * and not only notification payload.
+     * From Firebase Console: if only Notification Title/Notification Text are
+     * set, it won't call onMessageReceived(). It needs also Custom data fields set
+     * with title/body/id/silent
+     */
     @Override
     public void onMessageReceived(RemoteMessage remoteMessage) {
         if (debug) {

--- a/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/AndroidManifest.xml
+++ b/modules/push-notifications/src/main/resources/META-INF/substrate/dalvik/AndroidManifest.xml
@@ -31,5 +31,13 @@
             <meta-data android:name="android.support.PARENT_ACTIVITY"
                        android:value="com.gluonhq.helloandroid.MainActivity"/>
         </activity>
+        <receiver
+                android:name="com.gluonhq.helloandroid.FirebaseBroadcastReceiver"
+                android:exported="true"
+                android:permission="com.google.android.c2dm.permission.SEND">
+            <intent-filter>
+                <action android:name="com.google.android.c2dm.intent.RECEIVE" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>


### PR DESCRIPTION
 when app is closed or in background. When app is active in foreground, `PushFcmMessagingService::onMessageReceived` takes care of the push notification. 

Fixes #406 