### PR TITLE
StatusBarService: Add SystemBarsAppearance API

### DIFF
--- a/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/StatusBarService.java
+++ b/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/StatusBarService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Gluon
+ * Copyright (c) 2016, 2019 Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -59,15 +59,7 @@ public interface StatusBarService {
 
     /**
      * Sets the color of the status bar to the specified color.
-     * Up until Android 14
      * @param color The color to set the status bar to.
      */
     void setColor(Color color);
-
-    /**
-     * Sets the color of the status bar to the specified color, on Android 15+
-     * @param statusBarColor The color to set the status bar to.
-     * @param navigationBarColor The color to set the navigation bar to.
-     */
-    void setSystemBarsColor(Color statusBarColor, Color navigationBarColor);
 }

--- a/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/StatusBarService.java
+++ b/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/StatusBarService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019 Gluon
+ * Copyright (c) 2016, 2025, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -49,6 +49,11 @@ import java.util.Optional;
  */
 public interface StatusBarService {
 
+    enum APPEARANCE {
+        LIGHT,
+        DARK
+    }
+
     /**
      * Returns an instance of {@link StatusBarService}.
      * @return An instance of {@link StatusBarService}.
@@ -62,4 +67,13 @@ public interface StatusBarService {
      * @param color The color to set the status bar to.
      */
     void setColor(Color color);
+
+
+    /**
+     * Sets the appearance of the icons of the Status Bar to light or dark,
+     * so these have enough contrast and can be easily read
+     * Only applies to Android.
+     * @param appearance
+     */
+    void setStatusBarAppearance(APPEARANCE appearance);
 }

--- a/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/StatusBarService.java
+++ b/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/StatusBarService.java
@@ -70,10 +70,11 @@ public interface StatusBarService {
 
 
     /**
-     * Sets the appearance of the icons of the Status Bar to light or dark,
+     * Sets the appearance of the icons of the system bars to light or dark,
      * so these have enough contrast and can be easily read
      * Only applies to Android.
-     * @param appearance
+     * @param statusBarAppearance the light or dark appearance of the status bar
+     * @param navigationBarAppearance the light or dark appearance of the navigation bar
      */
-    void setStatusBarAppearance(APPEARANCE appearance);
+    void setSystemBarsAppearance(APPEARANCE statusBarAppearance, APPEARANCE navigationBarAppearance);
 }

--- a/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/impl/AndroidStatusBarService.java
+++ b/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/impl/AndroidStatusBarService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Gluon
+ * Copyright (c) 2016, 2025, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,6 +41,11 @@ public class AndroidStatusBarService implements StatusBarService {
         setNativeColor(getIntColor(color));
     }
 
+    @Override
+    public void setStatusBarAppearance(APPEARANCE appearance) {
+        setNativeDarkAppearance(appearance == APPEARANCE.DARK);
+    }
+
     private static int getIntColor(Color color) {
         if (color == null) {
             return 0xff000000; // Black
@@ -54,4 +59,5 @@ public class AndroidStatusBarService implements StatusBarService {
     }
 
     private native void setNativeColor(int color);
+    private native void setNativeDarkAppearance(boolean dark);
 }

--- a/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/impl/AndroidStatusBarService.java
+++ b/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/impl/AndroidStatusBarService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Gluon
+ * Copyright (c) 2016, 2020, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -41,11 +41,6 @@ public class AndroidStatusBarService implements StatusBarService {
         setNativeColor(getIntColor(color));
     }
 
-    @Override
-    public void setSystemBarsColor(Color statusBarColor, Color navigationBarColor) {
-        setNativeSystemBarsColor(getIntColor(statusBarColor), getIntColor(navigationBarColor));
-    }
-
     private static int getIntColor(Color color) {
         if (color == null) {
             return 0xff000000; // Black
@@ -59,6 +54,4 @@ public class AndroidStatusBarService implements StatusBarService {
     }
 
     private native void setNativeColor(int color);
-    private native void setNativeSystemBarsColor(int statusBarColor, int navigationBarColor);
-
 }

--- a/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/impl/AndroidStatusBarService.java
+++ b/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/impl/AndroidStatusBarService.java
@@ -42,8 +42,8 @@ public class AndroidStatusBarService implements StatusBarService {
     }
 
     @Override
-    public void setStatusBarAppearance(APPEARANCE appearance) {
-        setNativeDarkAppearance(appearance == APPEARANCE.DARK);
+    public void setSystemBarsAppearance(APPEARANCE statusBarAppearance, APPEARANCE navigationBarAppearance) {
+        setNativeSystemBarsAppearance(statusBarAppearance == APPEARANCE.DARK, navigationBarAppearance == APPEARANCE.DARK);
     }
 
     private static int getIntColor(Color color) {
@@ -59,5 +59,5 @@ public class AndroidStatusBarService implements StatusBarService {
     }
 
     private native void setNativeColor(int color);
-    private native void setNativeDarkAppearance(boolean dark);
+    private native void setNativeSystemBarsAppearance(boolean darkStatusBar, boolean darkNavigationBar);
 }

--- a/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/impl/IOSStatusBarService.java
+++ b/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/impl/IOSStatusBarService.java
@@ -42,7 +42,7 @@ public class IOSStatusBarService implements StatusBarService {
     }
 
     @Override
-    public void setStatusBarAppearance(APPEARANCE appearance) {
+    public void setSystemBarsAppearance(APPEARANCE statusBarAppearance, APPEARANCE navigationBarAppearance) {
         // no-op
     }
 

--- a/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/impl/IOSStatusBarService.java
+++ b/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/impl/IOSStatusBarService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2025, Gluon
+ * Copyright (c) 2016, 2019, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -39,11 +39,6 @@ public class IOSStatusBarService implements StatusBarService {
     @Override
     public void setColor(Color color) {
         setNativeColor(color.getRed(), color.getGreen(), color.getBlue(), color.getOpacity());
-    }
-
-    @Override
-    public void setSystemBarsColor(Color statusBarColor, Color navigationBarColor) {
-        // to-do
     }
 
     private native void setNativeColor(double red, double green, double blue, double opacity);

--- a/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/impl/IOSStatusBarService.java
+++ b/modules/statusbar/src/main/java/com/gluonhq/attach/statusbar/impl/IOSStatusBarService.java
@@ -41,5 +41,10 @@ public class IOSStatusBarService implements StatusBarService {
         setNativeColor(color.getRed(), color.getGreen(), color.getBlue(), color.getOpacity());
     }
 
+    @Override
+    public void setStatusBarAppearance(APPEARANCE appearance) {
+        // no-op
+    }
+
     private native void setNativeColor(double red, double green, double blue, double opacity);
 }

--- a/modules/statusbar/src/main/native/android/c/statusbar.c
+++ b/modules/statusbar/src/main/native/android/c/statusbar.c
@@ -37,7 +37,7 @@ static void initializeStatusBarDalvikHandles() {
     ATTACH_DALVIK();
     jmethodID jStatusBarServiceInitMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jStatusBarServiceClass, "<init>", "(Landroid/app/Activity;)V");
     jStatusBarServiceColorMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jStatusBarServiceClass, "setColor", "(I)V");
-    jStatusBarServiceDarkAppearanceMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jStatusBarServiceClass, "setDarkAppearance", "(Z)V");
+    jStatusBarServiceDarkAppearanceMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jStatusBarServiceClass, "setSystemBarsAppearance", "(ZZ)V");
 
     jobject jActivity = substrateGetActivity();
     jobject jtmpobj = (*dalvikEnv)->NewObject(dalvikEnv, jStatusBarServiceClass, jStatusBarServiceInitMethod, jActivity);
@@ -81,13 +81,14 @@ JNIEXPORT void JNICALL Java_com_gluonhq_attach_statusbar_impl_AndroidStatusBarSe
     DETACH_DALVIK();
 }
 
-JNIEXPORT void JNICALL Java_com_gluonhq_attach_statusbar_impl_AndroidStatusBarService_setNativeDarkAppearance
-(JNIEnv *env, jclass jClass, jboolean dark)
+JNIEXPORT void JNICALL Java_com_gluonhq_attach_statusbar_impl_AndroidStatusBarService_setNativeSystemBarsAppearance
+(JNIEnv *env, jclass jClass, jboolean darkStatusBar, jboolean darkNavigationBar)
 {
     ATTACH_DALVIK();
     if (isDebugAttach()) {
-        ATTACH_LOG_FINE("Set native dark appearance, value: %s", dark ? "true" : "false");
+        ATTACH_LOG_FINE("Set native status bar appearance dark: %s, navigation bar appearance dark: %s, ",
+                darkStatusBar ? "true" : "false", darkNavigationBar ? "true" : "false");
     }
-    (*dalvikEnv)->CallVoidMethod(dalvikEnv, jDalvikStatusBarService, jStatusBarServiceDarkAppearanceMethod, dark);
+    (*dalvikEnv)->CallVoidMethod(dalvikEnv, jDalvikStatusBarService, jStatusBarServiceDarkAppearanceMethod, darkStatusBar, darkNavigationBar);
     DETACH_DALVIK();
 }

--- a/modules/statusbar/src/main/native/android/c/statusbar.c
+++ b/modules/statusbar/src/main/native/android/c/statusbar.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2025, Gluon
+ * Copyright (c) 2020, 2021, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,14 +30,12 @@
 static jclass jStatusBarServiceClass;
 static jobject jDalvikStatusBarService;
 static jmethodID jStatusBarServiceColorMethod;
-static jmethodID jSystemBarsServiceColorMethod;
 
 static void initializeStatusBarDalvikHandles() {
     jStatusBarServiceClass = GET_REGISTER_DALVIK_CLASS(jStatusBarServiceClass, "com/gluonhq/helloandroid/DalvikStatusBarService");
     ATTACH_DALVIK();
     jmethodID jStatusBarServiceInitMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jStatusBarServiceClass, "<init>", "(Landroid/app/Activity;)V");
     jStatusBarServiceColorMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jStatusBarServiceClass, "setColor", "(I)V");
-    jSystemBarsServiceColorMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jStatusBarServiceClass, "setSystemBarsColor", "(II)V");
 
     jobject jActivity = substrateGetActivity();
     jobject jtmpobj = (*dalvikEnv)->NewObject(dalvikEnv, jStatusBarServiceClass, jStatusBarServiceInitMethod, jActivity);
@@ -78,16 +76,5 @@ JNIEXPORT void JNICALL Java_com_gluonhq_attach_statusbar_impl_AndroidStatusBarSe
         ATTACH_LOG_FINE("Set native color, value: %d", color);
     }
     (*dalvikEnv)->CallVoidMethod(dalvikEnv, jDalvikStatusBarService, jStatusBarServiceColorMethod, color);
-    DETACH_DALVIK();
-}
-
-JNIEXPORT void JNICALL Java_com_gluonhq_attach_statusbar_impl_AndroidStatusBarService_setNativeSystemBarsColor
-(JNIEnv *env, jclass jClass, jint statusBarColor, jint navigationBarColor)
-{
-    ATTACH_DALVIK();
-    if (isDebugAttach()) {
-        ATTACH_LOG_FINE("Set native system bars color, values: %d %d", statusBarColor, navigationBarColor);
-    }
-    (*dalvikEnv)->CallVoidMethod(dalvikEnv, jDalvikStatusBarService, jSystemBarsServiceColorMethod, statusBarColor, navigationBarColor);
     DETACH_DALVIK();
 }

--- a/modules/statusbar/src/main/native/android/c/statusbar.c
+++ b/modules/statusbar/src/main/native/android/c/statusbar.c
@@ -30,12 +30,14 @@
 static jclass jStatusBarServiceClass;
 static jobject jDalvikStatusBarService;
 static jmethodID jStatusBarServiceColorMethod;
+static jmethodID jStatusBarServiceDarkAppearanceMethod;
 
 static void initializeStatusBarDalvikHandles() {
     jStatusBarServiceClass = GET_REGISTER_DALVIK_CLASS(jStatusBarServiceClass, "com/gluonhq/helloandroid/DalvikStatusBarService");
     ATTACH_DALVIK();
     jmethodID jStatusBarServiceInitMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jStatusBarServiceClass, "<init>", "(Landroid/app/Activity;)V");
     jStatusBarServiceColorMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jStatusBarServiceClass, "setColor", "(I)V");
+    jStatusBarServiceDarkAppearanceMethod = (*dalvikEnv)->GetMethodID(dalvikEnv, jStatusBarServiceClass, "setDarkAppearance", "(Z)V");
 
     jobject jActivity = substrateGetActivity();
     jobject jtmpobj = (*dalvikEnv)->NewObject(dalvikEnv, jStatusBarServiceClass, jStatusBarServiceInitMethod, jActivity);
@@ -76,5 +78,16 @@ JNIEXPORT void JNICALL Java_com_gluonhq_attach_statusbar_impl_AndroidStatusBarSe
         ATTACH_LOG_FINE("Set native color, value: %d", color);
     }
     (*dalvikEnv)->CallVoidMethod(dalvikEnv, jDalvikStatusBarService, jStatusBarServiceColorMethod, color);
+    DETACH_DALVIK();
+}
+
+JNIEXPORT void JNICALL Java_com_gluonhq_attach_statusbar_impl_AndroidStatusBarService_setNativeDarkAppearance
+(JNIEnv *env, jclass jClass, jboolean dark)
+{
+    ATTACH_DALVIK();
+    if (isDebugAttach()) {
+        ATTACH_LOG_FINE("Set native dark appearance, value: %s", dark ? "true" : "false");
+    }
+    (*dalvikEnv)->CallVoidMethod(dalvikEnv, jDalvikStatusBarService, jStatusBarServiceDarkAppearanceMethod, dark);
     DETACH_DALVIK();
 }

--- a/modules/statusbar/src/main/native/android/dalvik/DalvikStatusBarService.java
+++ b/modules/statusbar/src/main/native/android/dalvik/DalvikStatusBarService.java
@@ -30,12 +30,10 @@ package com.gluonhq.helloandroid;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.drawable.ColorDrawable;
-import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
 import android.util.Log;
 import android.view.View;
 import android.view.Window;
-import android.view.WindowInsetsController;
 import android.view.WindowManager;
 
 public class DalvikStatusBarService {
@@ -50,11 +48,7 @@ public class DalvikStatusBarService {
 
     private void setColor(final int color) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) { // < 21
-            Log.e(TAG, "setColor is not supported for the current Android version");
-            return;
-        } else if (Build.VERSION.SDK_INT > Build.VERSION_CODES.UPSIDE_DOWN_CAKE) { // > 34
-            Log.e(TAG, "setColor is not supported for the current Android version. " +
-                    "Use setSystemBarsColor instead");
+            Log.e(TAG, "StatusBar service is not supported for the current Android version");
             return;
         }
         if (activity == null) {
@@ -70,66 +64,29 @@ public class DalvikStatusBarService {
             @Override
             public void run() {
                 Window window = activity.getWindow();
-                window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-                // make status bar transparent
-                window.setStatusBarColor(0x00000000);
-                // paint window
-                window.setBackgroundDrawable(new ColorDrawable(color));
-            }
-        });
-    }
+                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) { // <= 34
+                    window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+                    // make status bar transparent
+                    window.setStatusBarColor(0x00000000);
+                    // paint window
+                    window.setBackgroundDrawable(new ColorDrawable(color));
+                } else { // >= 35
+                    View decorView = window.getDecorView();
 
-    private void setSystemBarsColor(final int statusBarColor, final int navigationBarColor) {
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) { // < 34
-            Log.e(TAG, "setSystemBarsColor is not supported for the current Android version. " +
-                    "Use setColor instead");
-            return;
-        }
-        if (activity == null) {
-            Log.e(TAG, "FXActivity not found. This service is not allowed when "
-                    + "running in background mode or from wearable");
-            return;
-        }
+                    // Get insets, before applying the color, as it will reset them
+                    int top = decorView.getPaddingTop();
+                    int right = decorView.getPaddingRight();
+                    int bottom = decorView.getPaddingBottom();
+                    int left = decorView.getPaddingLeft();
 
-        if (Util.isDebug()) {
-            Log.v(TAG, "Set SystemBars color, values: " + statusBarColor + ", " + navigationBarColor);
-        }
-        activity.runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                Window window = activity.getWindow();
-                View decorView = window.getDecorView();
+                    // Apply color
+                    decorView.setBackground(new ColorDrawable(color));
 
-                // Get insets, before applying the color, as it will reset them
-                int top = decorView.getPaddingTop();
-                int right = decorView.getPaddingRight();
-                int bottom = decorView.getPaddingBottom();
-                int left = decorView.getPaddingLeft();
-
-                WindowInsetsController windowInsetsController = decorView.getWindowInsetsController();
-                if (windowInsetsController != null) {
-                    // background light color requires dark icons, dark light color, white icons
-                    int bitset = WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS;
-                    windowInsetsController.setSystemBarsAppearance(getLuma(statusBarColor) > 128 ?
-                                    bitset : 0, bitset);
+                    // Restore insets
+                    decorView.setPadding(left, top, right, bottom);
                 }
-
-                // Apply colors
-                decorView.setBackground(new GradientDrawable(
-                        GradientDrawable.Orientation.TOP_BOTTOM,
-                        new int[]{statusBarColor, navigationBarColor}));
-
-                // Restore insets
-                decorView.setPadding(left, top, right, bottom);
             }
         });
-    }
-
-    private static double getLuma(int color) {
-        int r = (color >> 16) & 0xff;
-        int g = (color >>  8) & 0xff;
-        int b = (color >>  0) & 0xff;
-        return 0.2126 * r + 0.7152 * g + 0.0722 * b; // 0 darkest - 255 lightest
     }
 
 }

--- a/modules/statusbar/src/main/native/android/dalvik/DalvikStatusBarService.java
+++ b/modules/statusbar/src/main/native/android/dalvik/DalvikStatusBarService.java
@@ -82,7 +82,7 @@ public class DalvikStatusBarService {
         });
     }
 
-    private void setDarkAppearance(final boolean dark) {
+    private void setSystemBarsAppearance(final boolean darkStatusBar, final boolean darkNavigationBar) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) { // < 21
             Log.e(TAG, "StatusBar service is not supported for the current Android version");
             return;
@@ -94,14 +94,15 @@ public class DalvikStatusBarService {
         }
 
         if (Util.isDebug()) {
-            Log.v(TAG, "Set StatusBar dark appearance, value: " + (dark ? "dark" : "light"));
+            Log.v(TAG, "Set StatusBar appearance: " + (darkStatusBar ? "dark" : "light") + ", NavigationBar appearance: " + (darkNavigationBar ? "dark" : "light"));
         }
         activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
                 Window window = activity.getWindow();
                 View decorView = window.getDecorView();
-                WindowCompat.getInsetsController(window, decorView).setAppearanceLightStatusBars(dark);
+                WindowCompat.getInsetsController(window, decorView).setAppearanceLightStatusBars(darkStatusBar);
+                WindowCompat.getInsetsController(window, decorView).setAppearanceLightNavigationBars(darkNavigationBar);
             }
         });
     }

--- a/modules/statusbar/src/main/native/android/dalvik/DalvikStatusBarService.java
+++ b/modules/statusbar/src/main/native/android/dalvik/DalvikStatusBarService.java
@@ -36,6 +36,8 @@ import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 
+import androidx.core.view.WindowCompat;
+
 public class DalvikStatusBarService {
 
     private static final String TAG = Util.TAG;
@@ -73,18 +75,33 @@ public class DalvikStatusBarService {
                 } else { // >= 35
                     View decorView = window.getDecorView();
 
-                    // Get insets, before applying the color, as it will reset them
-                    int top = decorView.getPaddingTop();
-                    int right = decorView.getPaddingRight();
-                    int bottom = decorView.getPaddingBottom();
-                    int left = decorView.getPaddingLeft();
-
                     // Apply color
                     decorView.setBackground(new ColorDrawable(color));
-
-                    // Restore insets
-                    decorView.setPadding(left, top, right, bottom);
                 }
+            }
+        });
+    }
+
+    private void setDarkAppearance(final boolean dark) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) { // < 21
+            Log.e(TAG, "StatusBar service is not supported for the current Android version");
+            return;
+        }
+        if (activity == null) {
+            Log.e(TAG, "FXActivity not found. This service is not allowed when "
+                    + "running in background mode or from wearable");
+            return;
+        }
+
+        if (Util.isDebug()) {
+            Log.v(TAG, "Set StatusBar dark appearance, value: " + (dark ? "dark" : "light"));
+        }
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                Window window = activity.getWindow();
+                View decorView = window.getDecorView();
+                WindowCompat.getInsetsController(window, decorView).setAppearanceLightStatusBars(dark);
             }
         });
     }

--- a/modules/statusbar/src/main/resources/META-INF/substrate/dalvik/android-dependencies.txt
+++ b/modules/statusbar/src/main/resources/META-INF/substrate/dalvik/android-dependencies.txt
@@ -1,0 +1,1 @@
+implementation 'androidx.core:core:1.13.0'

--- a/modules/statusbar/src/main/resources/META-INF/substrate/dalvik/build.gradle
+++ b/modules/statusbar/src/main/resources/META-INF/substrate/dalvik/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'com.android.library'
+
+android {
+
+    namespace 'com.gluonhq.helloandroid'
+
+    defaultConfig {
+        minSdkVersion 21
+        compileSdk 35
+        targetSdkVersion 35
+    }
+
+    dependencies {
+        compileOnly fileTree(dir: '../libs', include: '*.jar')
+        implementation 'androidx.core:core:1.13.0'
+    }
+
+    buildFeatures {
+        buildConfig = false
+        resValues = false
+    }
+}


### PR DESCRIPTION
This PR adds SystemBarsAppearance API, and removes SystemBarsColor API, which now is not needed since edge-to-edge layout is applied to all Android versions, and DisplayService has new API (#435) to retrieve the insets of the system bars.

With this new API, developers can set dark or light appearance for the icons of the system bars, so these have enough contrast to be readable.

