### PR TITLE
Update AndroidPicturesService to reduce memory usage and prevent leaks

### DIFF
--- a/modules/pictures/src/main/java/com/gluonhq/attach/pictures/impl/AndroidPicturesService.java
+++ b/modules/pictures/src/main/java/com/gluonhq/attach/pictures/impl/AndroidPicturesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Gluon
+ * Copyright (c) 2016, 2026, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,14 +33,10 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.scene.SnapshotParameters;
 import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-import javafx.scene.paint.Color;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -93,6 +89,7 @@ public class AndroidPicturesService implements PicturesService {
 
     private static final ObjectProperty<File> imageFile = new SimpleObjectProperty<>();
     private static final ReadOnlyObjectWrapper<Image> imageProperty = new ReadOnlyObjectWrapper<>();
+    private static final int MAX_IMAGE_DIMENSION = 1280;
     private static ObjectProperty<Image> result;
     private static boolean enteredLoop;
 
@@ -149,31 +146,28 @@ public class AndroidPicturesService implements PicturesService {
     public static native void selectPicture();
 
     // callback
-    public static void setResult(String filePath, int rotate) {
+    public static void setResult(String filePath) {
         LOG.fine("Got photo file at: " + filePath);
         File photoFile = new File(filePath);
         imageFile.set(photoFile);
-        Image initialImage = null;
-        try {
-            initialImage = new Image(new FileInputStream(photoFile));
-        } catch (FileNotFoundException e) {
-            LOG.severe("GalleryActivity: file not found: " + e);
+
+        // Release the old image reference and try to free resources
+        imageProperty.setValue(null);
+        System.gc();
+
+        Image image = null;
+        try (FileInputStream fis = new FileInputStream(photoFile)) {
+            image = new Image(fis, MAX_IMAGE_DIMENSION, MAX_IMAGE_DIMENSION, true, true);
+        } catch (Exception e) {
+            LOG.severe("GalleryActivity: error loading image: " + e);
         }
-        if (enteredLoop && (initialImage == null || rotate == 0)) {
-            result.set(initialImage);
+
+        final Image finalImage = image;
+        if (enteredLoop) {
+            result.set(finalImage);
         }
-        final Image finalImage = initialImage;
         Platform.runLater(() -> {
-            if (finalImage != null && rotate != 0) {
-                Image image = rotateImage(finalImage, rotate);
-                if (enteredLoop) {
-                    result.set(image);
-                } else {
-                    imageProperty.setValue(image);
-                }
-            } else {
-                imageProperty.setValue(finalImage);
-            }
+            imageProperty.setValue(finalImage);
             if (enteredLoop) {
                 enteredLoop = false;
                 try {
@@ -183,19 +177,5 @@ public class AndroidPicturesService implements PicturesService {
                 }
             }
         });
-    }
-
-    private static Image rotateImage(Image image, int rotate) {
-        if (image == null || rotate == 0) {
-            return image;
-        }
-        ImageView iv = new ImageView(image);
-        iv.setFitWidth(1280);
-        iv.setFitHeight(1280);
-        iv.setPreserveRatio(true);
-        iv.setRotate(rotate);
-        SnapshotParameters params = new SnapshotParameters();
-        params.setFill(Color.TRANSPARENT);
-        return iv.snapshot(params, null);
     }
 }

--- a/modules/pictures/src/main/java/com/gluonhq/attach/pictures/impl/AndroidPicturesService.java
+++ b/modules/pictures/src/main/java/com/gluonhq/attach/pictures/impl/AndroidPicturesService.java
@@ -146,17 +146,24 @@ public class AndroidPicturesService implements PicturesService {
     public static native void selectPicture();
 
     // callback
-    public static void setResult(String filePath) {
-        LOG.fine("Got photo file at: " + filePath);
-        File photoFile = new File(filePath);
-        imageFile.set(photoFile);
+    /**
+     * Called from native code with two file paths:
+     * @param originalFilePath  the full-resolution original file (for {@link #getImageFile()})
+     * @param processedFilePath the preprocessed (scaled+rotated) file (for {@link Image} loading)
+     */
+    public static void setResult(String originalFilePath, String processedFilePath) {
+        LOG.fine("Got photo file at: " + originalFilePath + " (processed: " + processedFilePath + ")");
+        File originalFile = new File(originalFilePath);
+        File processedFile = new File(processedFilePath);
+        imageFile.set(originalFile);
 
         // Release the old image reference and try to free resources
         imageProperty.setValue(null);
+        // ugly, but effective preventing vram pool from growing when taking many pictures
         System.gc();
 
         Image image = null;
-        try (FileInputStream fis = new FileInputStream(photoFile)) {
+        try (FileInputStream fis = new FileInputStream(processedFile)) {
             image = new Image(fis, MAX_IMAGE_DIMENSION, MAX_IMAGE_DIMENSION, true, true);
         } catch (Exception e) {
             LOG.severe("GalleryActivity: error loading image: " + e);

--- a/modules/pictures/src/main/native/android/c/pictures.c
+++ b/modules/pictures/src/main/native/android/c/pictures.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Gluon
+ * Copyright (c) 2020, 2026, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,7 +38,7 @@ static jmethodID jPicturesServiceSelectPictureMethod;
 
 void initializePicturesGraalHandles(JNIEnv *graalEnv) {
     jGraalPicturesClass = (*graalEnv)->NewGlobalRef(graalEnv, (*graalEnv)->FindClass(graalEnv, "com/gluonhq/attach/pictures/impl/AndroidPicturesService"));
-    jGraalSendPhotoFileMethod = (*graalEnv)->GetStaticMethodID(graalEnv, jGraalPicturesClass, "setResult", "(Ljava/lang/String;I)V");
+    jGraalSendPhotoFileMethod = (*graalEnv)->GetStaticMethodID(graalEnv, jGraalPicturesClass, "setResult", "(Ljava/lang/String;)V");
 }
 
 void initializePicturesDalvikHandles() {
@@ -101,14 +101,14 @@ JNIEXPORT void JNICALL Java_com_gluonhq_attach_pictures_impl_AndroidPicturesServ
 // From Dalvik to native //
 ///////////////////////////
 
-JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_DalvikPicturesService_sendPhotoFile(JNIEnv *env, jobject service, jstring path, jint rotate) {
+JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_DalvikPicturesService_sendPhotoFile(JNIEnv *env, jobject service, jstring path) {
     if (isDebugAttach()) {
         ATTACH_LOG_FINE("Send Photo File\n");
     }
     const char *pathChars = (*env)->GetStringUTFChars(env, path, NULL);
     ATTACH_GRAAL();
     jstring jpath = (*graalEnv)->NewStringUTF(graalEnv, pathChars);
-    (*graalEnv)->CallStaticVoidMethod(graalEnv, jGraalPicturesClass, jGraalSendPhotoFileMethod, jpath, rotate);
+    (*graalEnv)->CallStaticVoidMethod(graalEnv, jGraalPicturesClass, jGraalSendPhotoFileMethod, jpath);
     DETACH_GRAAL();
-    // (*env)->ReleaseStringUTFChars(env, jpath, jpathChars);
+    (*env)->ReleaseStringUTFChars(env, path, pathChars);
 }

--- a/modules/pictures/src/main/native/android/c/pictures.c
+++ b/modules/pictures/src/main/native/android/c/pictures.c
@@ -38,7 +38,7 @@ static jmethodID jPicturesServiceSelectPictureMethod;
 
 void initializePicturesGraalHandles(JNIEnv *graalEnv) {
     jGraalPicturesClass = (*graalEnv)->NewGlobalRef(graalEnv, (*graalEnv)->FindClass(graalEnv, "com/gluonhq/attach/pictures/impl/AndroidPicturesService"));
-    jGraalSendPhotoFileMethod = (*graalEnv)->GetStaticMethodID(graalEnv, jGraalPicturesClass, "setResult", "(Ljava/lang/String;)V");
+    jGraalSendPhotoFileMethod = (*graalEnv)->GetStaticMethodID(graalEnv, jGraalPicturesClass, "setResult", "(Ljava/lang/String;Ljava/lang/String;)V");
 }
 
 void initializePicturesDalvikHandles() {
@@ -101,14 +101,17 @@ JNIEXPORT void JNICALL Java_com_gluonhq_attach_pictures_impl_AndroidPicturesServ
 // From Dalvik to native //
 ///////////////////////////
 
-JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_DalvikPicturesService_sendPhotoFile(JNIEnv *env, jobject service, jstring path) {
+JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_DalvikPicturesService_sendPhotoFile(JNIEnv *env, jobject service, jstring originalPath, jstring processedPath) {
     if (isDebugAttach()) {
         ATTACH_LOG_FINE("Send Photo File\n");
     }
-    const char *pathChars = (*env)->GetStringUTFChars(env, path, NULL);
+    const char *originalChars = (*env)->GetStringUTFChars(env, originalPath, NULL);
+    const char *processedChars = (*env)->GetStringUTFChars(env, processedPath, NULL);
     ATTACH_GRAAL();
-    jstring jpath = (*graalEnv)->NewStringUTF(graalEnv, pathChars);
-    (*graalEnv)->CallStaticVoidMethod(graalEnv, jGraalPicturesClass, jGraalSendPhotoFileMethod, jpath);
+    jstring jOriginal = (*graalEnv)->NewStringUTF(graalEnv, originalChars);
+    jstring jProcessed = (*graalEnv)->NewStringUTF(graalEnv, processedChars);
+    (*graalEnv)->CallStaticVoidMethod(graalEnv, jGraalPicturesClass, jGraalSendPhotoFileMethod, jOriginal, jProcessed);
     DETACH_GRAAL();
-    (*env)->ReleaseStringUTFChars(env, path, pathChars);
+    (*env)->ReleaseStringUTFChars(env, originalPath, originalChars);
+    (*env)->ReleaseStringUTFChars(env, processedPath, processedChars);
 }

--- a/modules/pictures/src/main/native/android/dalvik/DalvikPicturesService.java
+++ b/modules/pictures/src/main/native/android/dalvik/DalvikPicturesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Gluon
+ * Copyright (c) 2020, 2026, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,6 +31,9 @@ import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
 import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
 import android.media.ExifInterface;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
@@ -41,6 +44,7 @@ import android.provider.OpenableColumns;
 import android.util.Log;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -63,6 +67,10 @@ public class DalvikPicturesService  {
 
     private final String authority;
     private String photoPath;
+
+    private static final int TARGET_SIZE = 1280;
+    private static final int JPEG_QUALITY = 85;
+    private static final byte[] DECODE_BUFFER = new byte[16 * 1024];
 
     public DalvikPicturesService(Activity activity) {
         this.activity = activity;
@@ -92,6 +100,7 @@ public class DalvikPicturesService  {
             Log.v(TAG, "Permission verification failed: Camera disabled");
             return;
         }
+        clearCache();
 
         Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
 
@@ -132,12 +141,16 @@ public class DalvikPicturesService  {
                         if (debug) {
                             Log.v(TAG, "Image file located at " + photoFile.getAbsolutePath() + " with rotation: " + imageRotation);
                         }
-                        sendPhotoFile(photoFile.getAbsolutePath(), imageRotation);
 
                         if (savePhoto) {
-                            // media scanner to rescan DIRECTORY_PICTURES after an image is saved/deleted
+                            // Saved photos: keep the original file untouched in
+                            // DIRECTORY_PICTURES, scan it into the gallery, and
+                            // send a preprocessed cache copy for display.
                             MediaScannerConnection.scanFile(activity, new String[]{photoFile.toString()}, null, null);
+                            photoFile = copyToCache(photoFile);
                         }
+                        preprocessImage(photoFile, imageRotation);
+                        sendPhotoFile(photoFile.getAbsolutePath());
                     } else {
                         Log.e(TAG, "Picture file doesn't exist for: " + photoFile.getAbsolutePath());
                     }
@@ -162,6 +175,8 @@ public class DalvikPicturesService  {
     }
 
     private void selectPicture() {
+        clearCache();
+
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
         intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         intent.setType("image/*");
@@ -193,7 +208,8 @@ public class DalvikPicturesService  {
                             if (debug) {
                                 Log.v(TAG, "Image file located at " + cachePhotoFile.getAbsolutePath() + " with rotation: " + imageRotation);
                             }
-                            sendPhotoFile(cachePhotoFile.getAbsolutePath(), imageRotation);
+                            preprocessImage(cachePhotoFile, imageRotation);
+                            sendPhotoFile(cachePhotoFile.getAbsolutePath());
                         }
                     }
                 }
@@ -232,7 +248,9 @@ public class DalvikPicturesService  {
         try {
             ExifInterface ei;
             if (Build.VERSION.SDK_INT > 23) {
-                ei = new ExifInterface(activity.getContentResolver().openInputStream(uri));
+                try (InputStream is = activity.getContentResolver().openInputStream(uri)) {
+                    ei = new ExifInterface(is);
+                }
             } else {
                 ei = new ExifInterface(uri.getPath());
             }
@@ -258,7 +276,7 @@ public class DalvikPicturesService  {
         File selectedFile = new File(activity.getCacheDir(), getImageName(uri));
         try (InputStream is = activity.getContentResolver().openInputStream(uri);
              OutputStream os = new FileOutputStream(selectedFile)) {
-            byte[] buffer = new byte[8 * 1024];
+            byte[] buffer = new byte[32 * 1024];
             int bytesRead;
             while ((bytesRead = is.read(buffer)) != -1) {
                 os.write(buffer, 0, bytesRead);
@@ -271,7 +289,105 @@ public class DalvikPicturesService  {
         return selectedFile;
     }
 
+    private File copyToCache(File source) {
+        File dest = new File(activity.getCacheDir(), "display_" + source.getName());
+        try (InputStream is = new FileInputStream(source); OutputStream os = new FileOutputStream(dest)) {
+            byte[] buffer = new byte[32 * 1024];
+            int bytesRead;
+            while ((bytesRead = is.read(buffer)) != -1) {
+                os.write(buffer, 0, bytesRead);
+            }
+        } catch (IOException ex) {
+            Log.e(TAG, "copyToCache failed: " + ex.getMessage());
+            return source; // fall back to original
+        }
+        return dest;
+    }
+
+    /**
+     * Scales and rotates the image file in place, with sub sampling and lower jpg quality,
+     * to reduce memory footprint
+     */
+    private void preprocessImage(File imageFile, int rotation) {
+        try {
+            // 1. Read dimensions only
+            BitmapFactory.Options opts = new BitmapFactory.Options();
+            opts.inJustDecodeBounds = true;
+            opts.inTempStorage = DECODE_BUFFER;
+            BitmapFactory.decodeFile(imageFile.getAbsolutePath(), opts);
+
+            // 2. Calculate inSampleSize
+            int srcW = opts.outWidth;
+            int srcH = opts.outHeight;
+            if (rotation == 90 || rotation == 270) {
+                srcW = opts.outHeight;
+                srcH = opts.outWidth;
+            }
+            opts.inSampleSize = calculateInSampleSize(srcW, srcH, TARGET_SIZE);
+            opts.inJustDecodeBounds = false;
+            opts.inPreferredConfig = Bitmap.Config.RGB_565;
+            opts.inTempStorage = DECODE_BUFFER;
+
+            // 3. Load sub-sampled bitmap
+            Bitmap bitmap = BitmapFactory.decodeFile(imageFile.getAbsolutePath(), opts);
+            if (bitmap == null) {
+                Log.e(TAG, "preprocessImage: failed to decode bitmap");
+                return;
+            }
+
+            try {
+                // 4. Build a single Matrix for scale + rotate combined
+                Matrix matrix = new Matrix();
+                float scale = Math.min(
+                        (float) TARGET_SIZE / bitmap.getWidth(),
+                        (float) TARGET_SIZE / bitmap.getHeight());
+                if (scale < 1.0f) {
+                    matrix.postScale(scale, scale);
+                }
+                if (rotation != 0) {
+                    // Rotate around the center of the image
+                    float cx = bitmap.getWidth() * Math.max(scale, 1.0f) / 2f;
+                    float cy = bitmap.getHeight() * Math.max(scale, 1.0f) / 2f;
+                    matrix.postRotate(rotation, cx, cy);
+                }
+
+                // 5. Apply combined transform
+                if (!matrix.isIdentity()) {
+                    Bitmap transformed = Bitmap.createBitmap(bitmap, 0, 0,
+                            bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+                    bitmap.recycle();
+                    bitmap = transformed;
+                }
+
+                // 6. Write processed image back to file
+                try (FileOutputStream fos = new FileOutputStream(imageFile)) {
+                    bitmap.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, fos);
+                }
+                if (debug) {
+                    Log.v(TAG, "preprocessImage: wrote " + bitmap.getWidth() + "x" + bitmap.getHeight()
+                            + " (rotation=" + rotation + ") to " + imageFile.getName());
+                }
+            } finally {
+                bitmap.recycle();
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "preprocessImage failed, falling back to original: " + e.getMessage());
+        }
+    }
+
+    private static int calculateInSampleSize(int width, int height, int targetSize) {
+        int inSampleSize = 1;
+        if (height > targetSize || width > targetSize) {
+            int halfH = height / 2;
+            int halfW = width / 2;
+            while ((halfH / inSampleSize) >= targetSize && (halfW / inSampleSize) >= targetSize) {
+                inSampleSize *= 2;
+            }
+        }
+        return inSampleSize;
+    }
+
     // native
-    private native void sendPhotoFile(String filePath, int rotate);
+    private native void sendPhotoFile(String filePath);
 
 }

--- a/modules/pictures/src/main/native/android/dalvik/DalvikPicturesService.java
+++ b/modules/pictures/src/main/native/android/dalvik/DalvikPicturesService.java
@@ -142,6 +142,8 @@ public class DalvikPicturesService  {
                             Log.v(TAG, "Image file located at " + photoFile.getAbsolutePath() + " with rotation: " + imageRotation);
                         }
 
+                        String originalPath = photoFile.getAbsolutePath();
+
                         if (savePhoto) {
                             // Saved photos: keep the original file untouched in
                             // DIRECTORY_PICTURES, scan it into the gallery, and
@@ -150,7 +152,7 @@ public class DalvikPicturesService  {
                             photoFile = copyToCache(photoFile);
                         }
                         preprocessImage(photoFile, imageRotation);
-                        sendPhotoFile(photoFile.getAbsolutePath());
+                        sendPhotoFile(originalPath, photoFile.getAbsolutePath());
                     } else {
                         Log.e(TAG, "Picture file doesn't exist for: " + photoFile.getAbsolutePath());
                     }
@@ -208,8 +210,9 @@ public class DalvikPicturesService  {
                             if (debug) {
                                 Log.v(TAG, "Image file located at " + cachePhotoFile.getAbsolutePath() + " with rotation: " + imageRotation);
                             }
+                            String originalPath = cachePhotoFile.getAbsolutePath();
                             preprocessImage(cachePhotoFile, imageRotation);
-                            sendPhotoFile(cachePhotoFile.getAbsolutePath());
+                            sendPhotoFile(originalPath, cachePhotoFile.getAbsolutePath());
                         }
                     }
                 }
@@ -388,6 +391,6 @@ public class DalvikPicturesService  {
     }
 
     // native
-    private native void sendPhotoFile(String filePath);
+    private native void sendPhotoFile(String originalFilePath, String processedFilePath);
 
 }

--- a/modules/pictures/src/main/resources/META-INF/substrate/config/jniconfig-aarch64-android.json
+++ b/modules/pictures/src/main/resources/META-INF/substrate/config/jniconfig-aarch64-android.json
@@ -1,6 +1,6 @@
 [
   {
     "name" : "com.gluonhq.attach.pictures.impl.AndroidPicturesService",
-    "methods":[{"name":"setResult","parameterTypes":["java.lang.String", "int"] }]
+    "methods":[{"name":"setResult","parameterTypes":["java.lang.String"] }]
   }
 ]

--- a/modules/pictures/src/main/resources/META-INF/substrate/config/jniconfig-aarch64-android.json
+++ b/modules/pictures/src/main/resources/META-INF/substrate/config/jniconfig-aarch64-android.json
@@ -1,6 +1,6 @@
 [
   {
     "name" : "com.gluonhq.attach.pictures.impl.AndroidPicturesService",
-    "methods":[{"name":"setResult","parameterTypes":["java.lang.String"] }]
+    "methods":[{"name":"setResult","parameterTypes":["java.lang.String","java.lang.String"] }]
   }
 ]


### PR DESCRIPTION
Fixes #440

This PR used on Android the same approach that was already done on iOS: rotate and scale down the big pictures in the native layer (while keeping the originals intact if saved), in order to pass to the Java/JavaFX layer a lower res and sized picture.
Some minor memory leaks have been fixed as well.
This removes the Vram issue reported in #440 (taken pictures repeatedly at a fast pace now doesn't cause an increase if Vram), as now the image operations doesn't happen in the JavaFX layer (rotation and snapshots are not needed anymore).
