### PR TITLE
Withdraw textPropertyForNode API, add removeKeyboardTypeForNode API

### DIFF
--- a/gradle/include/android/grandroid_ext.h
+++ b/gradle/include/android/grandroid_ext.h
@@ -58,11 +58,9 @@ jobject substrateGetActivity();
 #ifdef SUBSTRATE
 void __attribute__((weak)) attach_setActivityResult(jint requestCode, jint resultCode, jobject intent) {}
 void __attribute__((weak)) attach_setLifecycleEvent(const char *event) {}
-void __attribute__((weak)) attach_setComposingText(const char *id, const char *text) {}
 #else
 void attach_setActivityResult(jint requestCode, jint resultCode, jobject intent);
 void attach_setLifecycleEvent(const char *event);
-void attach_setComposingText(const char *id, const char *text);
 #endif
 
 #define ATTACH_GRAAL() \

--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/KeyboardService.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/KeyboardService.java
@@ -80,6 +80,16 @@ public interface KeyboardService {
     void keepVisibilityForNode(Node node, Parent parent);
 
     /**
+     * Stops adjusting the node when the software keyboard shows up,
+     * removing the listener previously registered via
+     * {@link #keepVisibilityForNode(Node)} or {@link #keepVisibilityForNode(Node, Parent)}.
+     *
+     * @param node the Node that was previously registered
+     * @since 4.0.25
+     */
+    void releaseVisibilityForNode(Node node);
+
+    /**
      * Gets the visible height of the Keyboard, so scene or views can adjusted
      * to prevent some of their content from being covered by the keyboard.
      *

--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/KeyboardService.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/KeyboardService.java
@@ -29,7 +29,6 @@ package com.gluonhq.attach.keyboard;
 
 import com.gluonhq.attach.util.Services;
 import javafx.beans.property.ReadOnlyFloatProperty;
-import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 
@@ -109,19 +108,5 @@ public interface KeyboardService {
      * @since 4.0.25
      */
     void setKeyboardTypeForNode(Node node, KeyboardType type);
-
-    /**
-     * Returns a read-only property that reflects the current composing text for the given node
-     * (typically a {@link javafx.scene.control.TextInputControl}), as reported by the native IME.
-     *
-     * <p>Note that the JavaFX text input control default {@code textProperty()} will still
-     * catch all the internals of the text composition when predictive text is enabled (that could show
-     * partial text being removed and added back again while the user is typing)</p>
-     *
-     * @param node the node whose text to observe
-     * @return a ReadOnlyStringProperty with the composed text for the given node
-     * @since 4.0.25
-     */
-    ReadOnlyStringProperty textPropertyForNode(Node node);
 
 }

--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/KeyboardService.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/KeyboardService.java
@@ -109,4 +109,14 @@ public interface KeyboardService {
      */
     void setKeyboardTypeForNode(Node node, KeyboardType type);
 
+    /**
+     * Removes the keyboard type assignment and event filter previously installed via
+     * {@link #setKeyboardTypeForNode(Node, KeyboardType)}. After this call the node
+     * will simply use the default keyboard type.
+     *
+     * @param node the node to unregister
+     * @since 4.0.25
+     */
+    void removeKeyboardTypeForNode(Node node);
+
 }

--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/AndroidKeyboardService.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/AndroidKeyboardService.java
@@ -28,9 +28,6 @@
 package com.gluonhq.attach.keyboard.impl;
 
 import javafx.application.Platform;
-import javafx.beans.property.ReadOnlyFloatProperty;
-import javafx.scene.Node;
-import javafx.scene.Parent;
 
 public class AndroidKeyboardService extends BaseKeyboardService {
 
@@ -41,20 +38,6 @@ public class AndroidKeyboardService extends BaseKeyboardService {
     public AndroidKeyboardService() {
     }
 
-    @Override
-    public void keepVisibilityForNode(Node node) {
-        keepVisibilityForNode(node, null);
-    }
-
-    @Override
-    public void keepVisibilityForNode(Node node, Parent parent) {
-        VISIBLE_HEIGHT.addListener((obs, ov, nv) -> adjustPosition(node, parent, nv.doubleValue()));
-    }
-
-    @Override
-    public ReadOnlyFloatProperty visibleHeightProperty() {
-        return VISIBLE_HEIGHT.getReadOnlyProperty();
-    }
 
     @Override
     protected void applyKeyboardType(int nativeValue) {

--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/AndroidKeyboardService.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/AndroidKeyboardService.java
@@ -60,12 +60,4 @@ public class AndroidKeyboardService extends BaseKeyboardService {
         }
     }
 
-    /**
-     * Called from keyboard.c when the native layer receives composing text
-     * tagged with a node id.
-     */
-    private static void notifyComposingText(String id, String text) {
-        updateTextForId(id, text);
-    }
-
 }

--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/BaseKeyboardService.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/BaseKeyboardService.java
@@ -33,9 +33,11 @@ import com.gluonhq.attach.util.Util;
 import javafx.animation.Interpolator;
 import javafx.animation.TranslateTransition;
 import javafx.application.Platform;
+import javafx.beans.property.ReadOnlyFloatProperty;
 import javafx.beans.property.ReadOnlyFloatWrapper;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.beans.value.ChangeListener;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.input.MouseEvent;
@@ -66,6 +68,9 @@ public abstract class BaseKeyboardService implements KeyboardService {
     /** Map of ids and nodes. */
     private static final Map<String, Node> idToNode = new HashMap<>();
 
+    /** Map of nodes to their visibility listeners. */
+    private final Map<Node, ChangeListener<Number>> visibilityListeners = new WeakHashMap<>();
+
     BaseKeyboardService() {
         VISIBLE_HEIGHT.addListener((obs, ov, nv) -> {
             if (nv != null && nv.doubleValue() <= 0) {
@@ -76,6 +81,34 @@ public abstract class BaseKeyboardService implements KeyboardService {
                 applyKeyboardType(KeyboardType.ASCII.getValue());
             }
         });
+    }
+
+    @Override
+    public void keepVisibilityForNode(Node node) {
+        keepVisibilityForNode(node, null);
+    }
+
+    @Override
+    public void keepVisibilityForNode(Node node, Parent parent) {
+        Objects.requireNonNull(node, "node must not be null");
+        releaseVisibilityForNode(node);
+        ChangeListener<Number> listener = (obs, ov, nv) -> adjustPosition(node, parent, nv.doubleValue());
+        visibilityListeners.put(node, listener);
+        VISIBLE_HEIGHT.addListener(listener);
+    }
+
+    @Override
+    public void releaseVisibilityForNode(Node node) {
+        Objects.requireNonNull(node, "node must not be null");
+        ChangeListener<Number> listener = visibilityListeners.remove(node);
+        if (listener != null) {
+            VISIBLE_HEIGHT.removeListener(listener);
+        }
+    }
+
+    @Override
+    public ReadOnlyFloatProperty visibleHeightProperty() {
+        return VISIBLE_HEIGHT.getReadOnlyProperty();
     }
 
     @Override

--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/BaseKeyboardService.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/BaseKeyboardService.java
@@ -35,14 +35,16 @@ import javafx.animation.TranslateTransition;
 import javafx.beans.property.ReadOnlyFloatProperty;
 import javafx.beans.property.ReadOnlyFloatWrapper;
 import javafx.beans.value.ChangeListener;
-import javafx.event.EventHandler;
+import javafx.beans.value.ObservableValue;
 import javafx.scene.Node;
 import javafx.scene.Parent;
-import javafx.scene.input.MouseEvent;
+import javafx.scene.Scene;
 import javafx.util.Duration;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -59,22 +61,13 @@ public abstract class BaseKeyboardService implements KeyboardService {
     /** Map of nodes and keyboard types. */
     private final Map<Node, KeyboardType> nodeKeyboardTypes = new WeakHashMap<>();
 
-    /** Map of nodes to their installed event filters. */
-    private final Map<Node, EventHandler<? super MouseEvent>> nodeEventFilters = new WeakHashMap<>();
-
     /** Map of nodes to their visibility listeners. */
     private final Map<Node, ChangeListener<Number>> visibilityListeners = new WeakHashMap<>();
 
+    /** Scenes for which a focusOwner listener has already been installed. */
+    private final Set<Scene> trackedScenes = Collections.newSetFromMap(new WeakHashMap<>());
+
     BaseKeyboardService() {
-        VISIBLE_HEIGHT.addListener((obs, ov, nv) -> {
-            if (nv != null && nv.doubleValue() <= 0) {
-                if (debug) {
-                    LOG.info("Keyboard hidden, reset default type");
-                }
-                applyActiveNodeId(""); // reset active node
-                applyKeyboardType(KeyboardType.ASCII.getValue());
-            }
-        });
     }
 
     @Override
@@ -110,38 +103,75 @@ public abstract class BaseKeyboardService implements KeyboardService {
         Objects.requireNonNull(node, "node must not be null");
         Objects.requireNonNull(type, "type must not be null");
         nodeKeyboardTypes.put(node, type);
-        installEventFilter(node);
+        attachFocusTracker(node);
     }
 
     @Override
     public void removeKeyboardTypeForNode(Node node) {
         Objects.requireNonNull(node, "node must not be null");
         nodeKeyboardTypes.remove(node);
-        uninstallEventFilter(node);
     }
 
-    private void installEventFilter(Node node) {
-        if (nodeEventFilters.containsKey(node)) {
+    /**
+     * Ensures a single focusOwner listener is installed on the scene that
+     * contains {@code node}. The listener drives the native keyboard type for
+     * every focus change in that scene, whether the newly focused node was
+     * explicitly registered via {@link #setKeyboardTypeForNode} or not.
+     * If {@code node} is not yet in a scene, the installation is deferred
+     * until it is.
+     */
+    private void attachFocusTracker(Node node) {
+        Scene scene = node.getScene();
+        if (scene != null) {
+            trackScene(scene);
+            // If this node is already the focus owner, apply its type now
+            if (scene.getFocusOwner() == node) {
+                applyTypeFor(node);
+            }
             return;
         }
-        EventHandler<? super MouseEvent> handler = e -> {
-            KeyboardType type = nodeKeyboardTypes.getOrDefault(node, KeyboardType.ASCII);
-            String id = syntheticId(node);
-            if (debug) {
-                LOG.info(String.format("Active keyboard type: %s for id %s", type, id));
+        node.sceneProperty().addListener(new ChangeListener<>() {
+            @Override
+            public void changed(ObservableValue<? extends Scene> obs, Scene ov, Scene nv) {
+                if (nv != null) {
+                    trackScene(nv);
+                    if (nv.getFocusOwner() == node) {
+                        applyTypeFor(node);
+                    }
+                    obs.removeListener(this);
+                }
             }
-            applyActiveNodeId(id);
-            applyKeyboardType(type.getValue());
-        };
-        nodeEventFilters.put(node, handler);
-        node.addEventFilter(MouseEvent.MOUSE_CLICKED, handler);
+        });
     }
 
-    private void uninstallEventFilter(Node node) {
-        EventHandler<? super MouseEvent> handler = nodeEventFilters.remove(node);
-        if (handler != null) {
-            node.removeEventFilter(MouseEvent.MOUSE_CLICKED, handler);
+    private void trackScene(Scene scene) {
+        if (!trackedScenes.add(scene)) {
+            return;
         }
+        scene.focusOwnerProperty().addListener((obs, ov, newNode) -> applyTypeFor(newNode));
+    }
+
+    /**
+     * Pushes the id and keyboard type for {@code focused} down to the native
+     * layer. Registered nodes use their stored {@link KeyboardType}; any other
+     * focus owner (including {@code null}) falls back to {@link KeyboardType#ASCII}.
+     */
+    private void applyTypeFor(Node focused) {
+        if (focused == null) {
+            if (debug) {
+                LOG.info("Focus cleared, applying default ASCII keyboard");
+            }
+            applyActiveNodeId("");
+            applyKeyboardType(KeyboardType.ASCII.getValue());
+            return;
+        }
+        KeyboardType type = nodeKeyboardTypes.getOrDefault(focused, KeyboardType.ASCII);
+        String id = syntheticId(focused);
+        if (debug) {
+            LOG.info(String.format("Active keyboard type: %s for id %s", type, id));
+        }
+        applyActiveNodeId(id);
+        applyKeyboardType(type.getValue());
     }
 
     /**

--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/BaseKeyboardService.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/BaseKeyboardService.java
@@ -32,18 +32,14 @@ import com.gluonhq.attach.keyboard.KeyboardType;
 import com.gluonhq.attach.util.Util;
 import javafx.animation.Interpolator;
 import javafx.animation.TranslateTransition;
-import javafx.application.Platform;
 import javafx.beans.property.ReadOnlyFloatProperty;
 import javafx.beans.property.ReadOnlyFloatWrapper;
-import javafx.beans.property.ReadOnlyStringProperty;
-import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.beans.value.ChangeListener;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.input.MouseEvent;
 import javafx.util.Duration;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.WeakHashMap;
@@ -62,11 +58,6 @@ public abstract class BaseKeyboardService implements KeyboardService {
     /** Map of nodes and keyboard types. */
     private final Map<Node, KeyboardType> nodeKeyboardTypes = new WeakHashMap<>();
 
-    /** Map of nodes and text properties. */
-    private static final Map<Node, ReadOnlyStringWrapper> nodeTextProperties = new WeakHashMap<>();
-
-    /** Map of ids and nodes. */
-    private static final Map<String, Node> idToNode = new HashMap<>();
 
     /** Map of nodes to their visibility listeners. */
     private final Map<Node, ChangeListener<Number>> visibilityListeners = new WeakHashMap<>();
@@ -119,16 +110,6 @@ public abstract class BaseKeyboardService implements KeyboardService {
         installEventFilter(node);
     }
 
-    @Override
-    public ReadOnlyStringProperty textPropertyForNode(Node node) {
-        Objects.requireNonNull(node, "node must not be null");
-        installEventFilter(node);
-        return nodeTextProperties.computeIfAbsent(node, n -> {
-            idToNode.put(syntheticId(n), n);
-            return new ReadOnlyStringWrapper("");
-        }).getReadOnlyProperty();
-    }
-
     private void installEventFilter(Node node) {
         node.addEventFilter(MouseEvent.MOUSE_CLICKED, e -> {
             KeyboardType type = nodeKeyboardTypes.getOrDefault(node, KeyboardType.ASCII);
@@ -149,20 +130,6 @@ public abstract class BaseKeyboardService implements KeyboardService {
         return id != null ? id : "attach-kb-" + System.identityHashCode(node);
     }
 
-    /**
-     * Called from the native callback to update the text property for the
-     * node identified by {@code id}.
-     */
-    protected static void updateTextForId(String id, String text) {
-        Node node = idToNode.get(id);
-        if (node == null) {
-            return;
-        }
-        ReadOnlyStringWrapper wrapper = nodeTextProperties.get(node);
-        if (wrapper != null && !Objects.equals(wrapper.get(), text)) {
-            Platform.runLater(() -> wrapper.set(text));
-        }
-    }
 
     protected static void adjustPosition(Node node, Parent parent, double kh) {
         if (node == null || node.getScene() == null || node.getScene().getWindow() == null) {

--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/BaseKeyboardService.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/BaseKeyboardService.java
@@ -35,6 +35,7 @@ import javafx.animation.TranslateTransition;
 import javafx.beans.property.ReadOnlyFloatProperty;
 import javafx.beans.property.ReadOnlyFloatWrapper;
 import javafx.beans.value.ChangeListener;
+import javafx.event.EventHandler;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.input.MouseEvent;
@@ -58,6 +59,8 @@ public abstract class BaseKeyboardService implements KeyboardService {
     /** Map of nodes and keyboard types. */
     private final Map<Node, KeyboardType> nodeKeyboardTypes = new WeakHashMap<>();
 
+    /** Map of nodes to their installed event filters. */
+    private final Map<Node, EventHandler<? super MouseEvent>> nodeEventFilters = new WeakHashMap<>();
 
     /** Map of nodes to their visibility listeners. */
     private final Map<Node, ChangeListener<Number>> visibilityListeners = new WeakHashMap<>();
@@ -110,15 +113,35 @@ public abstract class BaseKeyboardService implements KeyboardService {
         installEventFilter(node);
     }
 
+    @Override
+    public void removeKeyboardTypeForNode(Node node) {
+        Objects.requireNonNull(node, "node must not be null");
+        nodeKeyboardTypes.remove(node);
+        uninstallEventFilter(node);
+    }
+
     private void installEventFilter(Node node) {
-        node.addEventFilter(MouseEvent.MOUSE_CLICKED, e -> {
+        if (nodeEventFilters.containsKey(node)) {
+            return;
+        }
+        EventHandler<? super MouseEvent> handler = e -> {
             KeyboardType type = nodeKeyboardTypes.getOrDefault(node, KeyboardType.ASCII);
+            String id = syntheticId(node);
             if (debug) {
-                LOG.info(String.format("Active keyboard type: %s for id %s", type, syntheticId(node)));
+                LOG.info(String.format("Active keyboard type: %s for id %s", type, id));
             }
-            applyActiveNodeId(syntheticId(node));
+            applyActiveNodeId(id);
             applyKeyboardType(type.getValue());
-        });
+        };
+        nodeEventFilters.put(node, handler);
+        node.addEventFilter(MouseEvent.MOUSE_CLICKED, handler);
+    }
+
+    private void uninstallEventFilter(Node node) {
+        EventHandler<? super MouseEvent> handler = nodeEventFilters.remove(node);
+        if (handler != null) {
+            node.removeEventFilter(MouseEvent.MOUSE_CLICKED, handler);
+        }
     }
 
     /**
@@ -129,7 +152,6 @@ public abstract class BaseKeyboardService implements KeyboardService {
         String id = node.getId();
         return id != null ? id : "attach-kb-" + System.identityHashCode(node);
     }
-
 
     protected static void adjustPosition(Node node, Parent parent, double kh) {
         if (node == null || node.getScene() == null || node.getScene().getWindow() == null) {

--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/IOSKeyboardService.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/IOSKeyboardService.java
@@ -30,10 +30,8 @@ package com.gluonhq.attach.keyboard.impl;
 import com.gluonhq.attach.lifecycle.LifecycleEvent;
 import com.gluonhq.attach.lifecycle.LifecycleService;
 import javafx.application.Platform;
-import javafx.beans.property.ReadOnlyFloatProperty;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.scene.Node;
-import javafx.scene.Parent;
 import javafx.scene.control.TextInputControl;
 
 public class IOSKeyboardService extends BaseKeyboardService {
@@ -54,20 +52,6 @@ public class IOSKeyboardService extends BaseKeyboardService {
         startObserver();
     }
 
-    @Override
-    public void keepVisibilityForNode(Node node) {
-        keepVisibilityForNode(node, null);
-    }
-
-    @Override
-    public void keepVisibilityForNode(Node node, Parent parent) {
-        VISIBLE_HEIGHT.addListener((obs, ov, nv) -> adjustPosition(node, parent, nv.doubleValue()));
-    }
-
-    @Override
-    public ReadOnlyFloatProperty visibleHeightProperty() {
-        return VISIBLE_HEIGHT.getReadOnlyProperty();
-    }
 
     @Override
     protected void applyKeyboardType(int nativeValue) {

--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/IOSKeyboardService.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/impl/IOSKeyboardService.java
@@ -30,9 +30,6 @@ package com.gluonhq.attach.keyboard.impl;
 import com.gluonhq.attach.lifecycle.LifecycleEvent;
 import com.gluonhq.attach.lifecycle.LifecycleService;
 import javafx.application.Platform;
-import javafx.beans.property.ReadOnlyStringProperty;
-import javafx.scene.Node;
-import javafx.scene.control.TextInputControl;
 
 public class IOSKeyboardService extends BaseKeyboardService {
 
@@ -56,14 +53,6 @@ public class IOSKeyboardService extends BaseKeyboardService {
     @Override
     protected void applyKeyboardType(int nativeValue) {
         nativeSetKeyboardType(nativeValue);
-    }
-
-    @Override
-    public ReadOnlyStringProperty textPropertyForNode(Node node) {
-        if (node instanceof TextInputControl) {
-            return ((TextInputControl) node).textProperty();
-        }
-        return super.textPropertyForNode(node);
     }
 
     @Override

--- a/modules/keyboard/src/main/native/android/c/keyboard.c
+++ b/modules/keyboard/src/main/native/android/c/keyboard.c
@@ -53,7 +53,6 @@ JNI_OnLoad_keyboard(JavaVM *vm, void *reserved)
     ATTACH_LOG_FINE("Initializing native Keyboard from OnLoad");
     jAttachKeyboardClass = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "com/gluonhq/attach/keyboard/impl/AndroidKeyboardService"));
     jAttach_notifyHeightMethod = (*env)->GetStaticMethodID(env, jAttachKeyboardClass, "notifyVisibleHeight", "(F)V");
-    jAttach_notifyComposingTextMethod = (*env)->GetStaticMethodID(env, jAttachKeyboardClass, "notifyComposingText", "(Ljava/lang/String;Ljava/lang/String;)V");
     initKeyboard();
     ATTACH_LOG_FINE("Initializing native Keyboard done");
     return JNI_VERSION_1_8;
@@ -113,23 +112,6 @@ JNIEXPORT void JNICALL Java_com_gluonhq_attach_keyboard_impl_AndroidKeyboardServ
     DETACH_DALVIK();
     (*env)->ReleaseStringUTFChars(env, id, idChars);
     ATTACH_LOG_FINE("nativeSetActiveNodeId done");
-}
-
-//////////////////////////////////
-// native (Substrate) to Java   //
-//////////////////////////////////
-
-void attach_setComposingText(const char *id, const char *text)
-{
-    ATTACH_LOG_FINE("attach_setComposingText: forwarding to Graal: id=%s, text=%s", id, text);
-    ATTACH_GRAAL();
-    jstring graalId = (*graalEnv)->NewStringUTF(graalEnv, id);
-    jstring graalText = (*graalEnv)->NewStringUTF(graalEnv, text);
-    (*graalEnv)->CallStaticVoidMethod(graalEnv, jAttachKeyboardClass, jAttach_notifyComposingTextMethod, graalId, graalText);
-    (*graalEnv)->DeleteLocalRef(graalEnv, graalText);
-    (*graalEnv)->DeleteLocalRef(graalEnv, graalId);
-    DETACH_GRAAL();
-    ATTACH_LOG_FINE("attach_setComposingText done");
 }
 
 ///////////////////////////

--- a/modules/keyboard/src/main/native/android/c/keyboard.c
+++ b/modules/keyboard/src/main/native/android/c/keyboard.c
@@ -31,7 +31,6 @@ static jclass jKeyboardServiceClass;
 static jclass jAttachKeyboardClass;
 static jclass jActivityClass;
 static jmethodID jAttach_notifyHeightMethod;
-static jmethodID jAttach_notifyComposingTextMethod;
 static jmethodID jActivity_setKeyboardTypeMethod;
 static jmethodID jActivity_setActiveNodeIdMethod;
 

--- a/modules/keyboard/src/main/resources/META-INF/substrate/config/jniconfig-aarch64-android.json
+++ b/modules/keyboard/src/main/resources/META-INF/substrate/config/jniconfig-aarch64-android.json
@@ -2,8 +2,7 @@
   {
     "name" : "com.gluonhq.attach.keyboard.impl.AndroidKeyboardService",
     "methods":[
-      {"name":"notifyVisibleHeight","parameterTypes":["float"]},
-      {"name":"notifyComposingText","parameterTypes":["java.lang.String","java.lang.String"]}
+      {"name":"notifyVisibleHeight","parameterTypes":["float"]}
     ]
   }
 ]


### PR DESCRIPTION
This PR is a follow-up of #439 
- It withdraws the textPropertyForNode API: there is no point in having a textProperty outside the TextField (which can be easily out of sync if the textField is updated programatically or via JavaFX paste. Even if synced, it can't be used on the same textField, that is used for writing (so it would only make sense if this textField was wrapped with another control that showed only the composed text. To prevent changes from predictive text, the better option for now is some kind of batching mechanism that takes the text only after some time (preventing the internal changes that happen due to preventive text processing on Android).
- It adds removeKeyboardTypeForNode API, so nodes that were registered can be properly removed, if needed.
- It reworks the call to set the keyboard type, to prevent race conditions when the keyboard was hidden.