### PR TITLE
Use camera API in AndroidPicturesService

### DIFF
--- a/gradle/native-build.gradle
+++ b/gradle/native-build.gradle
@@ -193,11 +193,11 @@ ext.aarBuild = { buildDir, projectDir, name, os ->
         }
     }
     // use res
-    File res = file("$projectDir/src/main/resources/META-INF/substrate/dalvik/res/xml/file_provider_paths.xml")
-    if (res != null && res.exists()) {
+    File resDir = file("$projectDir/src/main/resources/META-INF/substrate/dalvik/res")
+    if (resDir != null && resDir.exists()) {
         project.copy {
-            from res
-            into file("$tempDir/library/src/main/res/xml/")
+            from resDir
+            into file("$tempDir/library/src/main/res/")
         }
     }
     // use dalvik assets

--- a/modules/pictures/src/main/java/com/gluonhq/attach/pictures/PicturesService.java
+++ b/modules/pictures/src/main/java/com/gluonhq/attach/pictures/PicturesService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Gluon
+ * Copyright (c) 2016, 2026, Gluon
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,7 +32,6 @@ import java.util.Optional;
 
 import com.gluonhq.attach.util.Services;
 import javafx.beans.property.ReadOnlyObjectProperty;
-import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.scene.image.Image;
 
 /**
@@ -78,41 +77,14 @@ import javafx.scene.image.Image;
  *
  * <p><b>Android Configuration</b></p>
  *
- * <p>Create the file {@code /src/android/res/xml/file_provider_paths.xml} with
- * the following content that allows access to the external storage:</p>
- * <pre>
- * {@code
- *    <?xml version="1.0" encoding="utf-8"?>
- *    <paths>
- *        <external-path name="external_files" path="." />
- *    </paths>
- * }
- * </pre>
- *
- * <p>The permission <code>android.permission.CAMERA</code> needs to be added as well as the permissions
- * <code>android.permission.READ_EXTERNAL_STORAGE</code> and <code>android.permission.WRITE_EXTERNAL_STORAGE</code>
- * to be able to read and write images. Also a {@code provider} is required:</p>
- *
- * <pre>
- * {@code <manifest package="${application.package.name}" ...>
- *    <uses-permission android:name="android.permission.CAMERA"/>
- *    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
- *    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
- *    <application ...>
- *       ...
- *       <activity android:name="com.gluonhq.attach.android.PermissionRequestActivity" />
- *       <provider
- *           android:name="android.support.v4.content.FileProvider"
- *           android:authorities="${application.package.name}.fileprovider"
- *           android:exported="false"
- *           android:grantUriPermissions="true">
- *           <meta-data
- *               android:name="android.support.FILE_PROVIDER_PATHS"
- *               android:resource="@xml/file_provider_paths" />
- *       </provider>
- *   </application>
- * </manifest>}
- * </pre>
+ * <p>The following permissions are required:</p>
+ * <ul>
+ *     <li><code>android.permission.CAMERA</code> — for taking photos with the device camera</li>
+ *     <li><code>android.permission.READ_MEDIA_IMAGES</code> — for reading images from the gallery (Android 13+)</li>
+ *     <li><code>android.permission.READ_MEDIA_AUDIO</code> — for reading audio files from the gallery (Android 13+)</li>
+ *     <li><code>android.permission.READ_MEDIA_VIDEO</code> — for reading video files from the gallery (Android 13+)</li>
+ *     <li><code>android.permission.READ_EXTERNAL_STORAGE</code> — for reading images from the gallery (Android 12 and below)</li>
+ * </ul>
  *
  *
  * <p><b>iOS Configuration</b></p>

--- a/modules/pictures/src/main/java/com/gluonhq/attach/pictures/impl/AndroidPicturesService.java
+++ b/modules/pictures/src/main/java/com/gluonhq/attach/pictures/impl/AndroidPicturesService.java
@@ -41,43 +41,19 @@ import java.util.Optional;
 import java.util.logging.Logger;
 
 /**
- * <p>Create the file {@code /src/android/res/xml/file_provider_paths.xml} with
- * the following content that allows access to the external storage or to
- * a temporal cache in case the picture is not saved:</p>
+ * Android implementation of the PicturesService.
  *
- * <pre>
- * {@code
- *    <?xml version="1.0" encoding="utf-8"?>
- *    <paths>
- *        <external-path name="external_files" path="." />
- *        <external-cache-path name="external_cache_files" path="." />
- *    </paths>
- * }
- * </pre>
+ * <p>Uses a custom camera implementation via CameraController for taking photos
+ * and the system gallery for selecting existing images.</p>
  *
- * <p>The permission <code>android.permission.CAMERA</code> needs to be added as well as the permissions
- * <code>android.permission.READ_EXTERNAL_STORAGE</code> and <code>android.permission.WRITE_EXTERNAL_STORAGE</code>
- * to be able to read and write images. Also a {@code provider} is required:</p>
- * <pre>
- * {@code <manifest package="${application.package.name}" ...>
- *    <uses-permission android:name="android.permission.CAMERA"/>
- *    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
- *    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
- *    <application ...>
- *       ...
- *       <activity android:name="com.gluonhq.helloandroid.PermissionRequestActivity" />
- *       <provider
- *           android:name="com.gluonhq.helloandroid.FileProvider"
- *           android:authorities="${application.package.name}.fileprovider"
- *           android:exported="false"
- *           android:grantUriPermissions="true">
- *           <meta-data
- *               android:name="android.support.FILE_PROVIDER_PATHS"
- *               android:resource="@xml/file_provider_paths" />
- *       </provider>
- *   </application>
- * </manifest>}
- * </pre>
+ * <p>Required permissions are automatically declared in AndroidManifest.xml:</p>
+ * <ul>
+ *     <li><code>android.permission.CAMERA</code></li>
+ *     <li><code>android.permission.READ_MEDIA_IMAGES</code> (Android 13+)</li>
+ *     <li><code>android.permission.READ_MEDIA_AUDIO</code> (Android 13+)</li>
+ *     <li><code>android.permission.READ_MEDIA_VIDEO</code> (Android 13+)</li>
+ *     <li><code>android.permission.READ_EXTERNAL_STORAGE</code> (Android 12 and below)</li>
+ * </ul>
  */
 public class AndroidPicturesService implements PicturesService {
 
@@ -152,6 +128,25 @@ public class AndroidPicturesService implements PicturesService {
      * @param processedFilePath the preprocessed (scaled+rotated) file (for {@link Image} loading)
      */
     public static void setResult(String originalFilePath, String processedFilePath) {
+        if (originalFilePath == null || originalFilePath.isEmpty()
+                || processedFilePath == null || processedFilePath.isEmpty()) {
+            LOG.fine("Picture request cancelled");
+            imageFile.set(null);
+            imageProperty.setValue(null);
+            if (enteredLoop) {
+                result.set(null);
+                Platform.runLater(() -> {
+                    enteredLoop = false;
+                    try {
+                        Platform.exitNestedEventLoop(result, null);
+                    } catch (Exception e) {
+                        LOG.severe("GalleryActivity: exitNestedEventLoop failed: " + e);
+                    }
+                });
+            }
+            return;
+        }
+
         LOG.fine("Got photo file at: " + originalFilePath + " (processed: " + processedFilePath + ")");
         File originalFile = new File(originalFilePath);
         File processedFile = new File(processedFilePath);

--- a/modules/pictures/src/main/native/android/c/pictures.c
+++ b/modules/pictures/src/main/native/android/c/pictures.c
@@ -111,7 +111,16 @@ JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_DalvikPicturesService_sendP
     jstring jOriginal = (*graalEnv)->NewStringUTF(graalEnv, originalChars);
     jstring jProcessed = (*graalEnv)->NewStringUTF(graalEnv, processedChars);
     (*graalEnv)->CallStaticVoidMethod(graalEnv, jGraalPicturesClass, jGraalSendPhotoFileMethod, jOriginal, jProcessed);
+    (*graalEnv)->DeleteLocalRef(graalEnv, jOriginal);
+    (*graalEnv)->DeleteLocalRef(graalEnv, jProcessed);
     DETACH_GRAAL();
     (*env)->ReleaseStringUTFChars(env, originalPath, originalChars);
     (*env)->ReleaseStringUTFChars(env, processedPath, processedChars);
 }
+
+JNIEXPORT void JNICALL Java_com_gluonhq_helloandroid_DalvikPicturesService_sendCancelled(JNIEnv *env, jobject service) {
+    ATTACH_GRAAL();
+    (*graalEnv)->CallStaticVoidMethod(graalEnv, jGraalPicturesClass, jGraalSendPhotoFileMethod, NULL, NULL);
+    DETACH_GRAAL();
+}
+

--- a/modules/pictures/src/main/native/android/dalvik/CameraBackHandler.java
+++ b/modules/pictures/src/main/native/android/dalvik/CameraBackHandler.java
@@ -31,8 +31,8 @@ import android.app.Activity;
 import android.os.Build;
 import android.view.KeyEvent;
 import android.view.View;
-import android.window.OnBackInvokedCallback;
-import android.window.OnBackInvokedDispatcher;
+
+import androidx.annotation.RequiresApi;
 
 /**
  * Manages the system back actions, closing the camera overlay
@@ -42,7 +42,7 @@ final class CameraBackHandler {
 
     private final Activity activity;
     private final Runnable onBack;
-    private OnBackInvokedCallback backInvokedCallback;
+    private Object backInvokedCallback;
 
     CameraBackHandler(Activity activity, Runnable onBack) {
         this.activity = activity;
@@ -51,15 +51,7 @@ final class CameraBackHandler {
 
     void attach(View root) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && backInvokedCallback == null) {
-            backInvokedCallback = new OnBackInvokedCallback() {
-                @Override
-                public void onBackInvoked() {
-                    onBack.run();
-                }
-            };
-            activity.getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
-                    OnBackInvokedDispatcher.PRIORITY_OVERLAY,
-                    backInvokedCallback);
+            backInvokedCallback = Api33BackBridge.register(activity, onBack);
         }
 
         if (root != null) {
@@ -80,11 +72,36 @@ final class CameraBackHandler {
 
     void detach(View root) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && backInvokedCallback != null) {
-            activity.getOnBackInvokedDispatcher().unregisterOnBackInvokedCallback(backInvokedCallback);
+            Api33BackBridge.unregister(activity, backInvokedCallback);
             backInvokedCallback = null;
         }
         if (root != null) {
             root.setOnKeyListener(null);
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private static final class Api33BackBridge {
+
+        private Api33BackBridge() {
+        }
+
+        private static android.window.OnBackInvokedCallback register(Activity activity, Runnable onBack) {
+            android.window.OnBackInvokedCallback callback = new android.window.OnBackInvokedCallback() {
+                @Override
+                public void onBackInvoked() {
+                    onBack.run();
+                }
+            };
+            activity.getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
+                    android.window.OnBackInvokedDispatcher.PRIORITY_OVERLAY,
+                    callback);
+            return callback;
+        }
+
+        private static void unregister(Activity activity, Object callback) {
+            activity.getOnBackInvokedDispatcher().unregisterOnBackInvokedCallback(
+                    (android.window.OnBackInvokedCallback) callback);
         }
     }
 }

--- a/modules/pictures/src/main/native/android/dalvik/CameraBackHandler.java
+++ b/modules/pictures/src/main/native/android/dalvik/CameraBackHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.helloandroid;
+
+import android.app.Activity;
+import android.os.Build;
+import android.view.KeyEvent;
+import android.view.View;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
+
+/**
+ * Manages the system back actions, closing the camera overlay
+ * when the user presses the Back system button.
+ */
+final class CameraBackHandler {
+
+    private final Activity activity;
+    private final Runnable onBack;
+    private OnBackInvokedCallback backInvokedCallback;
+
+    CameraBackHandler(Activity activity, Runnable onBack) {
+        this.activity = activity;
+        this.onBack = onBack;
+    }
+
+    void attach(View root) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && backInvokedCallback == null) {
+            backInvokedCallback = new OnBackInvokedCallback() {
+                @Override
+                public void onBackInvoked() {
+                    onBack.run();
+                }
+            };
+            activity.getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
+                    OnBackInvokedDispatcher.PRIORITY_OVERLAY,
+                    backInvokedCallback);
+        }
+
+        if (root != null) {
+            root.setFocusableInTouchMode(true);
+            root.requestFocus();
+            root.setOnKeyListener(new View.OnKeyListener() {
+                @Override
+                public boolean onKey(View v, int keyCode, KeyEvent event) {
+                    if (keyCode == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_UP) {
+                        onBack.run();
+                        return true;
+                    }
+                    return false;
+                }
+            });
+        }
+    }
+
+    void detach(View root) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && backInvokedCallback != null) {
+            activity.getOnBackInvokedDispatcher().unregisterOnBackInvokedCallback(backInvokedCallback);
+            backInvokedCallback = null;
+        }
+        if (root != null) {
+            root.setOnKeyListener(null);
+        }
+    }
+}
+

--- a/modules/pictures/src/main/native/android/dalvik/CameraController.java
+++ b/modules/pictures/src/main/native/android/dalvik/CameraController.java
@@ -306,9 +306,19 @@ final class CameraController {
             @Override
             public void onError(@NonNull ImageCaptureException exception) {
                 Log.e(tag, "Camera capture failed: " + exception.getMessage());
+                cleanupFailedCaptureFile(targetFile);
                 closeCamera(true);
             }
         });
+    }
+
+    private void cleanupFailedCaptureFile(File targetFile) {
+        if (targetFile == null || !targetFile.exists()) {
+            return;
+        }
+        if (!targetFile.delete() && debug) {
+            Log.v(tag, "Failed to delete capture file after error: " + targetFile.getAbsolutePath());
+        }
     }
 
     private void closeCamera(final boolean notifyCancel) {

--- a/modules/pictures/src/main/native/android/dalvik/CameraController.java
+++ b/modules/pictures/src/main/native/android/dalvik/CameraController.java
@@ -1,0 +1,424 @@
+/*
+ * Copyright (c) 2026, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.helloandroid;
+
+import android.app.Activity;
+import android.hardware.display.DisplayManager;
+import android.util.Log;
+import android.view.ScaleGestureDetector;
+import android.view.Surface;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.camera.camera2.Camera2Config;
+import androidx.camera.core.AspectRatio;
+import androidx.camera.core.Camera;
+import androidx.camera.core.CameraSelector;
+import androidx.camera.core.ImageCapture;
+import androidx.camera.core.ImageCaptureException;
+import androidx.camera.core.Preview;
+import androidx.camera.core.ZoomState;
+import androidx.camera.lifecycle.ProcessCameraProvider;
+import androidx.camera.view.PreviewView;
+import androidx.core.content.ContextCompat;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
+
+import java.io.File;
+import java.util.concurrent.Executor;
+import com.google.common.util.concurrent.ListenableFuture;
+
+/**
+ * Coordinates the Android camera capture flow for the pictures service.
+ * It wires together the overlay, rotation handling, Camera binding,
+ * capture actions, zoom gestures, and orderly shutdown callbacks.
+ */
+final class CameraController {
+
+    interface Listener {
+        void onCaptured(File targetFile, boolean savePhoto);
+        void onCancelled();
+    }
+
+    private static final int LENS_BACK = 0;
+    private static final int LENS_FRONT = 1;
+    private final Activity activity;
+    private final String tag;
+    private final boolean debug;
+    private final Listener listener;
+    private final ViewGroup viewGroup;
+    private final CameraOverlayView overlayView;
+    private final CameraRotationController rotationController;
+
+    private ProcessCameraProvider cameraProvider;
+    private Camera boundCamera;
+    private ImageCapture imageCapture;
+    private CameraLifecycleOwner cameraLifecycleOwner;
+    private ScaleGestureDetector zoomGestureDetector;
+    private final CameraBackHandler backHandler;
+
+    private boolean cameraVisible;
+    private int currentLensFacing = LENS_BACK;
+
+    private Preview previewUseCase;
+    private int lastTargetRotation = Surface.ROTATION_0;
+
+    CameraController(Activity activity, String tag, boolean debug, Listener listener) {
+        this.activity = activity;
+        this.tag = tag;
+        this.debug = debug;
+        this.listener = listener;
+        this.viewGroup = (ViewGroup) activity.getWindow().getDecorView();
+        this.overlayView = new CameraOverlayView(activity, new View.OnTouchListener() {
+            @Override
+            public boolean onTouch(View v, android.view.MotionEvent event) {
+                return zoomGestureDetector != null && zoomGestureDetector.onTouchEvent(event);
+            }
+        });
+        this.rotationController = new CameraRotationController(
+                activity,
+                (DisplayManager) activity.getSystemService(Activity.DISPLAY_SERVICE),
+                new CameraRotationController.PreviewViewProvider() {
+                    @Override
+                    public PreviewView getPreviewView() {
+                        return overlayView.getPreviewViewOrNull();
+                    }
+                },
+                new CameraRotationController.Listener() {
+                    @Override
+                    public void onDisplayRotationCommitted() {
+                        if (cameraVisible) {
+                            rebindForRotation();
+                        }
+                    }
+
+                    @Override
+                    public void onStableOrientationChanged(int targetRotation) {
+                        if (cameraVisible) {
+                            updateTargetRotation(targetRotation, false);
+                        }
+                    }
+                });
+        this.backHandler = new CameraBackHandler(activity, new Runnable() {
+            @Override
+            public void run() {
+                closeCamera(true);
+            }
+        });
+        this.lastTargetRotation = resolveTargetRotation();
+    }
+
+    boolean start(final boolean savePhoto, final File targetFile) {
+        if (targetFile == null) {
+            return false;
+        }
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    if (cameraVisible) {
+                        return;
+                    }
+                    ensureZoomGestureDetector();
+                    overlayView.attachTo(viewGroup);
+                    rotationController.start();
+                    backHandler.attach(overlayView.getRoot());
+                    cameraVisible = true;
+                    bindCamera(savePhoto, targetFile);
+                } catch (Exception e) {
+                    Log.e(tag, "Camera startup failed: " + e.getMessage());
+                    closeCamera(false);
+                    listener.onCancelled();
+                }
+            }
+        });
+        return true;
+    }
+
+
+    private void bindCamera(final boolean savePhoto, final File targetFile) {
+        if (cameraLifecycleOwner == null) {
+            cameraLifecycleOwner = new CameraLifecycleOwner();
+        }
+        cameraLifecycleOwner.start();
+
+        final Executor mainExecutor = ContextCompat.getMainExecutor(activity);
+        overlayView.prepareForBind();
+        ensureCameraConfigured();
+        ListenableFuture<ProcessCameraProvider> providerFuture = ProcessCameraProvider.getInstance(activity);
+        providerFuture.addListener(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    cameraProvider = providerFuture.get();
+                    boolean hasBack = cameraProvider.hasCamera(CameraSelector.DEFAULT_BACK_CAMERA);
+                    boolean hasFront = cameraProvider.hasCamera(CameraSelector.DEFAULT_FRONT_CAMERA);
+                    if (!hasBack && !hasFront) {
+                        throw new IllegalStateException("No camera available for Camera mode");
+                    }
+                    if (currentLensFacing == LENS_FRONT && !hasFront) {
+                        currentLensFacing = LENS_BACK;
+                    }
+                    if (currentLensFacing == LENS_BACK && !hasBack) {
+                        currentLensFacing = LENS_FRONT;
+                    }
+                    overlayView.setFlipVisible(hasBack && hasFront);
+
+                    bindCameraUseCases();
+
+                    overlayView.setCancelClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                            closeCamera(true);
+                        }
+                    });
+                    overlayView.setCaptureClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                            captureCameraPhoto(savePhoto, targetFile, mainExecutor);
+                        }
+                    });
+                    overlayView.setFlipClickListener(new View.OnClickListener() {
+                        @Override
+                        public void onClick(View v) {
+                            toggleLens();
+                        }
+                    });
+                } catch (Exception e) {
+                    Log.e(tag, "Camera bind failed: " + e.getMessage());
+                    closeCamera(false);
+                    listener.onCancelled();
+                }
+            }
+        }, mainExecutor);
+    }
+
+    private void ensureZoomGestureDetector() {
+        if (zoomGestureDetector != null) {
+            return;
+        }
+        zoomGestureDetector = new ScaleGestureDetector(activity, new ScaleGestureDetector.SimpleOnScaleGestureListener() {
+            @Override
+            public boolean onScale(ScaleGestureDetector detector) {
+                return applyPinchZoom(detector.getScaleFactor());
+            }
+        });
+    }
+
+    private void ensureCameraConfigured() {
+        try {
+            ProcessCameraProvider.configureInstance(Camera2Config.defaultConfig());
+        } catch (IllegalStateException alreadyConfigured) {
+            // No-op: Camera can only be configured once per process.
+        } catch (Throwable t) {
+            if (debug) {
+                Log.v(tag, "Camera configureInstance skipped: " + t.getMessage());
+            }
+        }
+    }
+
+    private void bindCameraUseCases() {
+        int targetRotation = resolveTargetRotation();
+        previewUseCase = new Preview.Builder()
+                .setTargetAspectRatio(AspectRatio.RATIO_4_3)
+                .setTargetRotation(targetRotation)
+                .build();
+        previewUseCase.setSurfaceProvider(overlayView.getPreviewView().getSurfaceProvider());
+        imageCapture = new ImageCapture.Builder()
+                .setTargetAspectRatio(AspectRatio.RATIO_4_3)
+                .setTargetRotation(targetRotation)
+                .build();
+        cameraProvider.unbindAll();
+        boundCamera = cameraProvider.bindToLifecycle(cameraLifecycleOwner, getCurrentSelector(), previewUseCase, imageCapture);
+        lastTargetRotation = targetRotation;
+        if (debug) {
+            String lens = currentLensFacing == LENS_FRONT ? "front" : "back";
+            Log.v(tag, "Camera bound to " + lens + " lens");
+        }
+    }
+
+    private CameraSelector getCurrentSelector() {
+        return currentLensFacing == LENS_FRONT
+                ? CameraSelector.DEFAULT_FRONT_CAMERA
+                : CameraSelector.DEFAULT_BACK_CAMERA;
+    }
+
+    private void toggleLens() {
+        if (cameraProvider == null) {
+            return;
+        }
+        int previousLens = currentLensFacing;
+        currentLensFacing = currentLensFacing == LENS_BACK ? LENS_FRONT : LENS_BACK;
+        try {
+            bindCameraUseCases();
+        } catch (Exception e) {
+            currentLensFacing = previousLens;
+            try {
+                bindCameraUseCases();
+            } catch (Exception retryEx) {
+                Log.e(tag, "Camera lens switch failed: " + retryEx.getMessage());
+                closeCamera(true);
+            }
+        }
+    }
+
+    private void captureCameraPhoto(final boolean savePhoto, final File targetFile, Executor mainExecutor) {
+        if (imageCapture == null) {
+            Log.e(tag, "Camera imageCapture is null");
+            return;
+        }
+
+        ImageCapture.OutputFileOptions opts = new ImageCapture.OutputFileOptions.Builder(targetFile).build();
+        imageCapture.takePicture(opts, mainExecutor, new ImageCapture.OnImageSavedCallback() {
+            @Override
+            public void onImageSaved(@NonNull ImageCapture.OutputFileResults outputFileResults) {
+                closeCamera(false);
+                listener.onCaptured(targetFile, savePhoto);
+            }
+
+            @Override
+            public void onError(@NonNull ImageCaptureException exception) {
+                Log.e(tag, "Camera capture failed: " + exception.getMessage());
+                closeCamera(true);
+            }
+        });
+    }
+
+    private void closeCamera(final boolean notifyCancel) {
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                if (!cameraVisible) {
+                    return;
+                }
+                backHandler.detach(overlayView.getRootOrNull());
+                rotationController.stop();
+                if (cameraProvider != null) {
+                    cameraProvider.unbindAll();
+                }
+                if (cameraLifecycleOwner != null) {
+                    cameraLifecycleOwner.stop();
+                }
+                overlayView.detachFrom(viewGroup);
+                overlayView.onClosed();
+                boundCamera = null;
+                previewUseCase = null;
+                imageCapture = null;
+                cameraVisible = false;
+                if (notifyCancel) {
+                    listener.onCancelled();
+                }
+            }
+        });
+    }
+
+    private int resolveTargetRotation() {
+        lastTargetRotation = rotationController.getCurrentTargetRotation();
+        return lastTargetRotation;
+    }
+
+    private void rebindForRotation() {
+        if (cameraProvider == null || cameraLifecycleOwner == null) {
+            return;
+        }
+        int newRotation = resolveTargetRotation();
+        if (newRotation == lastTargetRotation) {
+            return;
+        }
+        // No cover for rotation rebinds: in COMPATIBLE (TextureView) mode the surface is
+        // NOT destroyed on unbind, so the TextureView freezes on the last frame until the
+        // new stream arrives.  Showing a cover would add an unnecessary ~400 ms black delay.
+        try {
+            bindCameraUseCases();
+        } catch (Exception e) {
+            Log.w(tag, "Rebind after display rotation failed: " + e.getMessage());
+        }
+    }
+
+    private void updateTargetRotation(int targetRotation, boolean rebind) {
+        if (targetRotation == lastTargetRotation) {
+            return;
+        }
+        lastTargetRotation = targetRotation;
+        if (previewUseCase != null) {
+            previewUseCase.setTargetRotation(targetRotation);
+        }
+        if (imageCapture != null) {
+            imageCapture.setTargetRotation(targetRotation);
+        }
+        if (rebind && cameraProvider != null && cameraLifecycleOwner != null) {
+            try {
+                bindCameraUseCases();
+            } catch (Exception e) {
+                Log.w(tag, "Rebind after rotation failed: " + e.getMessage());
+            }
+        }
+    }
+
+
+    private boolean applyPinchZoom(float scaleFactor) {
+        if (boundCamera == null) {
+            return false;
+        }
+        ZoomState zoomState = boundCamera.getCameraInfo().getZoomState().getValue();
+        if (zoomState == null) {
+            return false;
+        }
+        float nextZoom = zoomState.getZoomRatio() * scaleFactor;
+        nextZoom = Math.max(zoomState.getMinZoomRatio(), Math.min(nextZoom, zoomState.getMaxZoomRatio()));
+        boundCamera.getCameraControl().setZoomRatio(nextZoom);
+        return true;
+    }
+
+    private static class CameraLifecycleOwner implements LifecycleOwner {
+
+        private final LifecycleRegistry lifecycleRegistry;
+
+        private CameraLifecycleOwner() {
+            lifecycleRegistry = new LifecycleRegistry(this);
+            lifecycleRegistry.setCurrentState(Lifecycle.State.CREATED);
+        }
+
+        @Override
+        @NonNull
+        public Lifecycle getLifecycle() {
+            return lifecycleRegistry;
+        }
+
+        private void start() {
+            lifecycleRegistry.setCurrentState(Lifecycle.State.STARTED);
+        }
+
+        private void stop() {
+            lifecycleRegistry.setCurrentState(Lifecycle.State.CREATED);
+        }
+    }
+}
+

--- a/modules/pictures/src/main/native/android/dalvik/CameraOverlayView.java
+++ b/modules/pictures/src/main/native/android/dalvik/CameraOverlayView.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2026, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.helloandroid;
+
+import android.app.Activity;
+import android.content.res.ColorStateList;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.RippleDrawable;
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.FrameLayout;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+
+import androidx.camera.view.PreviewView;
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.core.view.ViewCompat;
+
+/**
+ * Builds and manages the temporary full-screen camera overlay UI.
+ * Manages the preview view, startup cover, action buttons, and
+ * layout details used while the camera is visible.
+ */
+final class CameraOverlayView {
+
+    private static final int SMALL_RADIUS = 52;
+    private static final int BIG_RADIUS = 74;
+
+    private final Activity activity;
+    private final DisplayMetrics displayMetrics;
+    private final View.OnTouchListener previewTouchListener;
+
+    private FrameLayout root;
+    private PreviewView previewView;
+    private View startupCover;
+    private Button captureButton;
+    private Button cancelButton;
+    private ImageButton flipButton;
+    private PreviewStreamCoverController previewStreamCoverController;
+
+    private int systemInsetLeft;
+    private int systemInsetTop;
+    private int systemInsetRight;
+    private int systemInsetBottom;
+
+    CameraOverlayView(Activity activity, View.OnTouchListener previewTouchListener) {
+        this.activity = activity;
+        this.displayMetrics = activity.getResources().getDisplayMetrics();
+        this.previewTouchListener = previewTouchListener;
+    }
+
+    void attachTo(ViewGroup parent) {
+        ensureViews();
+        applyFrameLayout();
+        if (root.getParent() == null) {
+            parent.addView(root);
+            ViewCompat.requestApplyInsets(root);
+        }
+    }
+
+    void detachFrom(ViewGroup parent) {
+        if (root != null && root.getParent() == parent) {
+            parent.removeView(root);
+        }
+    }
+
+    FrameLayout getRoot() {
+        ensureViews();
+        return root;
+    }
+
+    FrameLayout getRootOrNull() {
+        return root;
+    }
+
+    PreviewView getPreviewView() {
+        ensureViews();
+        return previewView;
+    }
+
+    PreviewView getPreviewViewOrNull() {
+        return previewView;
+    }
+
+    void setCancelClickListener(View.OnClickListener listener) {
+        ensureViews();
+        cancelButton.setOnClickListener(listener);
+    }
+
+    void setCaptureClickListener(View.OnClickListener listener) {
+        ensureViews();
+        captureButton.setOnClickListener(listener);
+    }
+
+    void setFlipClickListener(View.OnClickListener listener) {
+        ensureViews();
+        flipButton.setOnClickListener(listener);
+    }
+
+    void setFlipVisible(boolean visible) {
+        ensureViews();
+        flipButton.setVisibility(visible ? View.VISIBLE : View.GONE);
+    }
+
+    void prepareForBind() {
+        ensureViews();
+        previewStreamCoverController.prepareForBind();
+        previewStreamCoverController.attach();
+    }
+
+    void onClosed() {
+        if (previewStreamCoverController != null) {
+            previewStreamCoverController.detach();
+        }
+    }
+
+    private void ensureViews() {
+        if (root != null) {
+            return;
+        }
+
+        root = new FrameLayout(activity);
+        root.setBackgroundColor(0xFF111111);
+
+        previewView = new PreviewView(activity);
+        previewView.setImplementationMode(PreviewView.ImplementationMode.COMPATIBLE);
+        previewView.setScaleType(PreviewView.ScaleType.FIT_CENTER);
+        previewView.setBackgroundColor(Color.BLACK);
+        previewView.setOnTouchListener(previewTouchListener);
+        root.addView(previewView, new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                Gravity.CENTER));
+
+        startupCover = new View(activity);
+        startupCover.setBackgroundColor(Color.BLACK);
+        root.addView(startupCover, new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                Gravity.CENTER));
+        previewStreamCoverController = new PreviewStreamCoverController(previewView, startupCover);
+
+        FrameLayout controlsContainer = new FrameLayout(activity);
+        FrameLayout.LayoutParams controlsLp = new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                Gravity.BOTTOM);
+        controlsContainer.setLayoutParams(controlsLp);
+
+        cancelButton = createSymbolButton("\u2715", SMALL_RADIUS, 0xCC666666, Color.TRANSPARENT, 0, 24f, Color.WHITE);
+        int radius = dpToPx(SMALL_RADIUS);
+        FrameLayout.LayoutParams cancelLp = new FrameLayout.LayoutParams(
+                radius, radius, Gravity.START | Gravity.BOTTOM);
+        controlsContainer.addView(cancelButton, cancelLp);
+
+        flipButton = createIconButton(R.drawable.ic_flip_camera, SMALL_RADIUS, 40, 0xCC666666);
+        FrameLayout.LayoutParams flipLp = new FrameLayout.LayoutParams(
+                radius, radius, Gravity.END | Gravity.BOTTOM);
+        controlsContainer.addView(flipButton, flipLp);
+
+        captureButton = createSymbolButton("", BIG_RADIUS, 0xFFDDDDDD, 0xAA777777, 2, 0f, Color.TRANSPARENT);
+        FrameLayout.LayoutParams captureLp = new FrameLayout.LayoutParams(
+                dpToPx(BIG_RADIUS), dpToPx(BIG_RADIUS), Gravity.CENTER_HORIZONTAL | Gravity.BOTTOM);
+        controlsContainer.addView(captureButton, captureLp);
+
+        root.addView(controlsContainer);
+
+        ViewCompat.setOnApplyWindowInsetsListener(root, (v, insets) -> {
+            systemInsetLeft = insets.getSystemWindowInsetLeft();
+            systemInsetTop = insets.getSystemWindowInsetTop();
+            systemInsetRight = insets.getSystemWindowInsetRight();
+            systemInsetBottom = insets.getSystemWindowInsetBottom();
+            applyInsetsAwareLayout();
+            return insets;
+        });
+        applyInsetsAwareLayout();
+    }
+
+    private void applyFrameLayout() {
+        if (root == null) {
+            return;
+        }
+        FrameLayout.LayoutParams lp = new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                Gravity.CENTER);
+        lp.setMargins(0, 0, 0, 0);
+        root.setLayoutParams(lp);
+        applyInsetsAwareLayout();
+    }
+
+    private int dpToPx(int dp) {
+        return Math.round(dp * displayMetrics.density);
+    }
+
+    private Button createSymbolButton(String symbol, int diameterDp, int fillColor, int strokeColor,
+                                      int strokeWidthDp, float textSizeSp, int textColor) {
+        Button button = new Button(activity);
+        button.setIncludeFontPadding(false);
+        button.setPadding(0, 0, 0, 0);
+        button.setTypeface(Typeface.DEFAULT_BOLD);
+        button.setText(symbol);
+        button.setTextColor(textColor);
+        if (textSizeSp > 0f) {
+            button.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSizeSp);
+        }
+        button.setBackground(createCircularButtonBackground(fillColor, strokeColor, strokeWidthDp));
+
+        int diameterPx = dpToPx(diameterDp);
+        button.setWidth(diameterPx);
+        button.setHeight(diameterPx);
+        return button;
+    }
+
+    private ImageButton createIconButton(int drawableResId, int diameterDp, int iconSizeDp, int fillColor) {
+        ImageButton button = new ImageButton(activity);
+        button.setScaleType(ImageView.ScaleType.FIT_CENTER);
+        button.setAdjustViewBounds(false);
+        int diameterPx = dpToPx(diameterDp);
+        int iconSizePx = Math.min(dpToPx(iconSizeDp), diameterPx);
+        int insetPx = Math.max(0, (diameterPx - iconSizePx) / 2);
+        button.setPadding(insetPx, insetPx, insetPx, insetPx);
+        button.setBackground(createCircularButtonBackground(fillColor, Color.TRANSPARENT, 0));
+
+        Drawable icon = ContextCompat.getDrawable(activity, drawableResId);
+        if (icon != null) {
+            Drawable wrapped = DrawableCompat.wrap(icon.mutate());
+            DrawableCompat.setTint(wrapped, Color.WHITE);
+            button.setImageDrawable(wrapped);
+        }
+        return button;
+    }
+
+    private Drawable createCircularButtonBackground(int fillColor, int strokeColor, int strokeWidthDp) {
+        GradientDrawable content = new GradientDrawable();
+        content.setShape(GradientDrawable.OVAL);
+        content.setColor(fillColor);
+        content.setStroke(dpToPx(strokeWidthDp), strokeColor);
+
+        GradientDrawable mask = new GradientDrawable();
+        mask.setShape(GradientDrawable.OVAL);
+        mask.setColor(Color.WHITE);
+
+        return new RippleDrawable(ColorStateList.valueOf(0x4DFFFFFF), content, mask);
+    }
+
+    private void applyInsetsAwareLayout() {
+        if (root == null || cancelButton == null || captureButton == null) {
+            return;
+        }
+
+        int margin = dpToPx(16);
+        int sideMargin = margin;
+        int bottomMargin = margin + systemInsetBottom;
+        int topMargin = margin;
+
+        FrameLayout.LayoutParams cancelLp = (FrameLayout.LayoutParams) cancelButton.getLayoutParams();
+        cancelLp.setMargins(sideMargin + systemInsetLeft, topMargin, sideMargin, bottomMargin);
+        cancelButton.setLayoutParams(cancelLp);
+
+        FrameLayout.LayoutParams captureLp = (FrameLayout.LayoutParams) captureButton.getLayoutParams();
+        captureLp.setMargins(sideMargin + systemInsetLeft, topMargin, sideMargin + systemInsetRight, bottomMargin);
+        captureButton.setLayoutParams(captureLp);
+
+        if (flipButton != null) {
+            FrameLayout.LayoutParams flipLp = (FrameLayout.LayoutParams) flipButton.getLayoutParams();
+            flipLp.setMargins(sideMargin, topMargin, sideMargin + systemInsetRight, bottomMargin);
+            flipButton.setLayoutParams(flipLp);
+        }
+
+        root.setPadding(systemInsetLeft, systemInsetTop, systemInsetRight, 0);
+    }
+}
+

--- a/modules/pictures/src/main/native/android/dalvik/CameraRotationController.java
+++ b/modules/pictures/src/main/native/android/dalvik/CameraRotationController.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.helloandroid;
+
+import android.app.Activity;
+import android.hardware.display.DisplayManager;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.OrientationEventListener;
+import android.view.Surface;
+
+import androidx.camera.view.PreviewView;
+
+/**
+ * Tracks display and sensor rotation changes for the camera overlay.
+ * It deals with orientation events, maps them to Surface rotations,
+ * and reports stable rotation updates back to the controller.
+ */
+final class CameraRotationController {
+
+    interface PreviewViewProvider {
+        PreviewView getPreviewView();
+    }
+
+    interface Listener {
+        void onDisplayRotationCommitted();
+        void onStableOrientationChanged(int targetRotation);
+    }
+
+    private static final long ORIENTATION_DEBOUNCE_MS = 150;
+
+    private final Activity activity;
+    private final DisplayManager displayManager;
+    private final PreviewViewProvider previewViewProvider;
+    private final Listener listener;
+    private final Handler orientationHandler = new Handler(Looper.getMainLooper());
+
+    private boolean started;
+    private boolean displayListenerRegistered;
+    private OrientationEventListener orientationListener;
+    private boolean orientationListenerEnabled;
+    private Runnable pendingOrientationUpdate;
+
+    private final DisplayManager.DisplayListener displayListener = new DisplayManager.DisplayListener() {
+        @Override
+        public void onDisplayAdded(int displayId) {
+            // no-op
+        }
+
+        @Override
+        public void onDisplayRemoved(int displayId) {
+            // no-op
+        }
+
+        @Override
+        public void onDisplayChanged(int displayId) {
+            PreviewView previewView = previewViewProvider.getPreviewView();
+            if (!started || previewView == null || previewView.getDisplay() == null) {
+                return;
+            }
+            if (previewView.getDisplay().getDisplayId() == displayId) {
+                cancelPendingOrientationUpdate();
+                listener.onDisplayRotationCommitted();
+            }
+        }
+    };
+
+    CameraRotationController(Activity activity,
+                             DisplayManager displayManager,
+                             PreviewViewProvider previewViewProvider,
+                             Listener listener) {
+        this.activity = activity;
+        this.displayManager = displayManager;
+        this.previewViewProvider = previewViewProvider;
+        this.listener = listener;
+    }
+
+    void start() {
+        started = true;
+        registerDisplayListener();
+        registerOrientationListener();
+    }
+
+    void stop() {
+        started = false;
+        unregisterDisplayListener();
+        unregisterOrientationListener();
+    }
+
+    int getCurrentTargetRotation() {
+        PreviewView previewView = previewViewProvider.getPreviewView();
+        if (previewView != null && previewView.getDisplay() != null) {
+            return previewView.getDisplay().getRotation();
+        }
+        return Surface.ROTATION_0;
+    }
+
+    private void registerDisplayListener() {
+        if (displayListenerRegistered || displayManager == null) {
+            return;
+        }
+        displayManager.registerDisplayListener(displayListener, null);
+        displayListenerRegistered = true;
+    }
+
+    private void unregisterDisplayListener() {
+        if (!displayListenerRegistered || displayManager == null) {
+            return;
+        }
+        displayManager.unregisterDisplayListener(displayListener);
+        displayListenerRegistered = false;
+    }
+
+    private void registerOrientationListener() {
+        if (orientationListenerEnabled) {
+            return;
+        }
+        if (orientationListener == null) {
+            orientationListener = new OrientationEventListener(activity) {
+                @Override
+                public void onOrientationChanged(int orientation) {
+                    if (orientation == ORIENTATION_UNKNOWN || !started) {
+                        return;
+                    }
+                    final int targetRotation = mapOrientationToTargetRotation(orientation);
+                    cancelPendingOrientationUpdate();
+                    pendingOrientationUpdate = new Runnable() {
+                        @Override
+                        public void run() {
+                            pendingOrientationUpdate = null;
+                            if (started) {
+                                listener.onStableOrientationChanged(targetRotation);
+                            }
+                        }
+                    };
+                    orientationHandler.postDelayed(pendingOrientationUpdate, ORIENTATION_DEBOUNCE_MS);
+                }
+            };
+        }
+        if (orientationListener.canDetectOrientation()) {
+            orientationListener.enable();
+            orientationListenerEnabled = true;
+        }
+    }
+
+    private void unregisterOrientationListener() {
+        cancelPendingOrientationUpdate();
+        if (orientationListener != null && orientationListenerEnabled) {
+            orientationListener.disable();
+            orientationListenerEnabled = false;
+        }
+    }
+
+    private void cancelPendingOrientationUpdate() {
+        if (pendingOrientationUpdate != null) {
+            orientationHandler.removeCallbacks(pendingOrientationUpdate);
+            pendingOrientationUpdate = null;
+        }
+    }
+
+    private int mapOrientationToTargetRotation(int orientation) {
+        if (orientation >= 315 || orientation < 45) {
+            return Surface.ROTATION_0;
+        } else if (orientation < 135) {
+            return Surface.ROTATION_270;
+        } else if (orientation < 225) {
+            return Surface.ROTATION_180;
+        } else {
+            return Surface.ROTATION_90;
+        }
+    }
+}
+

--- a/modules/pictures/src/main/native/android/dalvik/DalvikPicturesService.java
+++ b/modules/pictures/src/main/native/android/dalvik/DalvikPicturesService.java
@@ -31,15 +31,11 @@ import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
 import android.database.Cursor;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.graphics.Matrix;
 import android.media.ExifInterface;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
-import android.provider.MediaStore;
 import android.provider.OpenableColumns;
 import android.util.Log;
 
@@ -55,28 +51,45 @@ import java.util.Date;
 
 import static android.app.Activity.RESULT_OK;
 
+/**
+ * Entry point for the pictures service Android implementation.
+ * It verifies permissions, stages capture files, preprocesses images,
+ * and bridges camera results back to the native Attach layer.
+ */
 public class DalvikPicturesService  {
 
     private static final String TAG = Util.TAG;
     private static final int SELECT_PICTURE = 1;
-    private static final int TAKE_PICTURE = 2;
 
     private final Activity activity;
     private final boolean debug;
     private boolean verified;
 
-    private final String authority;
     private String photoPath;
 
-    private static final int TARGET_SIZE = 1280;
-    private static final int JPEG_QUALITY = 85;
-    private static final byte[] DECODE_BUFFER = new byte[16 * 1024];
+    private CameraController cameraController;
 
     public DalvikPicturesService(Activity activity) {
         this.activity = activity;
         this.debug = Util.isDebug();
-        authority = activity.getPackageName() + ".fileprovider";
         clearCache();
+    }
+
+    private CameraController getOrCreateCameraController() {
+        if (cameraController == null) {
+            cameraController = new CameraController(activity, TAG, debug, new CameraController.Listener() {
+                @Override
+                public void onCaptured(File targetFile, boolean savePhoto) {
+                    handleCapturedPhoto(targetFile, savePhoto);
+                }
+
+                @Override
+                public void onCancelled() {
+                    sendCancelled();
+                }
+            });
+        }
+        return cameraController;
     }
 
     private boolean verifyPermissions() {
@@ -101,79 +114,57 @@ public class DalvikPicturesService  {
             return;
         }
         clearCache();
-
-        Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
-
-        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
-        // Create the file where the photo should go
-        try {
-            File photo = savePhoto ? new File(Environment.getExternalStoragePublicDirectory(
-                    Environment.DIRECTORY_PICTURES), "IMG_"+ timeStamp + ".jpg") :
-                    File.createTempFile("IMG_"+ timeStamp, ".jpg", activity.getCacheDir());
-            if (photo.exists()) {
-                photo.delete();
-            } else {
-                photo.getParentFile().mkdirs();
-            }
-            photoPath = "file:" + photo.getAbsolutePath();
-            if (debug) {
-                Log.v(TAG, "Picture file: " + photoPath);
-            }
-
-            Uri photoUri = FileProvider.getUriForFile(activity, authority, photo);
-            intent.putExtra(MediaStore.EXTRA_OUTPUT, photoUri);
-            intent.setFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-        } catch (IOException e) {
-            Log.e(TAG, "Error creating file " + e.getMessage());
-        }
-
-        IntentHandler intentHandler = new IntentHandler() {
-            @Override
-            public void gotActivityResult (int requestCode, int resultCode, Intent intent) {
-                if (requestCode == TAKE_PICTURE && resultCode == RESULT_OK) {
-                    if (debug) {
-                        Log.v(TAG, "Picture successfully taken at " + photoPath);
-                    }
-                    Uri imageUri = Uri.parse(photoPath);
-                    File photoFile = new File(imageUri.getPath());
-                    if (photoFile.exists()) {
-                        int imageRotation = getImageRotation(imageUri);
-                        if (debug) {
-                            Log.v(TAG, "Image file located at " + photoFile.getAbsolutePath() + " with rotation: " + imageRotation);
-                        }
-
-                        String originalPath = photoFile.getAbsolutePath();
-
-                        if (savePhoto) {
-                            // Saved photos: keep the original file untouched in
-                            // DIRECTORY_PICTURES, scan it into the gallery, and
-                            // send a preprocessed cache copy for display.
-                            MediaScannerConnection.scanFile(activity, new String[]{photoFile.toString()}, null, null);
-                            photoFile = copyToCache(photoFile);
-                        }
-                        preprocessImage(photoFile, imageRotation);
-                        sendPhotoFile(originalPath, photoFile.getAbsolutePath());
-                    } else {
-                        Log.e(TAG, "Picture file doesn't exist for: " + photoFile.getAbsolutePath());
-                    }
-                }
-            }
-        };
-
-        if (activity == null) {
-            Log.e(TAG, "Activity not found. This service is not allowed when "
-                    + "running in background mode or from wearable");
+        File photoFile = createCaptureFile(savePhoto);
+        if (photoFile == null) {
+            sendCancelled();
             return;
         }
-
-        Util.setOnActivityResultHandler(intentHandler);
-
-        // check for permissions
-        if (intent.resolveActivity(activity.getPackageManager()) != null) {
-            activity.startActivityForResult(intent, TAKE_PICTURE);
-        } else {
-            Log.e(TAG, "GalleryActivity: resolveActivity failed");
+        photoPath = "file:" + photoFile.getAbsolutePath();
+        if (debug) {
+            Log.v(TAG, "Camera capture requested. Picture file: " + photoPath);
         }
+        if (!getOrCreateCameraController().start(savePhoto, photoFile)) {
+            Log.e(TAG, "Camera startup failed");
+            sendCancelled();
+        }
+    }
+
+    private File createCaptureFile(boolean savePhoto) {
+        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+        try {
+            File photo = savePhoto
+                    ? new File(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES), "IMG_" + timeStamp + ".jpg")
+                    : File.createTempFile("IMG_" + timeStamp, ".jpg", activity.getCacheDir());
+            if (photo.exists()) {
+                photo.delete();
+            } else if (photo.getParentFile() != null) {
+                photo.getParentFile().mkdirs();
+            }
+            return photo;
+        } catch (IOException e) {
+            Log.e(TAG, "Error creating file " + e.getMessage());
+            return null;
+        }
+    }
+
+    private void handleCapturedPhoto(File photoFile, boolean savePhoto) {
+        if (photoFile == null || !photoFile.exists()) {
+            Log.e(TAG, "Picture file doesn't exist for: " + (photoFile == null ? "null" : photoFile.getAbsolutePath()));
+            return;
+        }
+        Uri imageUri = Uri.fromFile(photoFile);
+        int imageRotation = getImageRotation(imageUri);
+        if (debug) {
+            Log.v(TAG, "Image file located at " + photoFile.getAbsolutePath() + " with rotation: " + imageRotation);
+        }
+
+        String originalPath = photoFile.getAbsolutePath();
+        if (savePhoto) {
+            MediaScannerConnection.scanFile(activity, new String[]{photoFile.toString()}, null, null);
+            photoFile = copyToCache(photoFile);
+        }
+        ImagePreprocessor.preprocessImage(photoFile, imageRotation, debug, TAG);
+        sendPhotoFile(originalPath, photoFile.getAbsolutePath());
     }
 
     private void selectPicture() {
@@ -211,10 +202,12 @@ public class DalvikPicturesService  {
                                 Log.v(TAG, "Image file located at " + cachePhotoFile.getAbsolutePath() + " with rotation: " + imageRotation);
                             }
                             String originalPath = cachePhotoFile.getAbsolutePath();
-                            preprocessImage(cachePhotoFile, imageRotation);
+                            ImagePreprocessor.preprocessImage(cachePhotoFile, imageRotation, debug, TAG);
                             sendPhotoFile(originalPath, cachePhotoFile.getAbsolutePath());
                         }
                     }
+                } else if (requestCode == SELECT_PICTURE) {
+                    sendCancelled();
                 }
             }
         };
@@ -231,6 +224,9 @@ public class DalvikPicturesService  {
 
     private void clearCache() {
         File[] files = activity.getCacheDir().listFiles();
+        if (files == null) {
+            return;
+        }
         for (File file : files) {
             if (file.exists() && file.getName().endsWith(".jpg")) {
                 file.delete();
@@ -307,90 +303,8 @@ public class DalvikPicturesService  {
         return dest;
     }
 
-    /**
-     * Scales and rotates the image file in place, with sub sampling and lower jpg quality,
-     * to reduce memory footprint
-     */
-    private void preprocessImage(File imageFile, int rotation) {
-        try {
-            // 1. Read dimensions only
-            BitmapFactory.Options opts = new BitmapFactory.Options();
-            opts.inJustDecodeBounds = true;
-            opts.inTempStorage = DECODE_BUFFER;
-            BitmapFactory.decodeFile(imageFile.getAbsolutePath(), opts);
-
-            // 2. Calculate inSampleSize
-            int srcW = opts.outWidth;
-            int srcH = opts.outHeight;
-            if (rotation == 90 || rotation == 270) {
-                srcW = opts.outHeight;
-                srcH = opts.outWidth;
-            }
-            opts.inSampleSize = calculateInSampleSize(srcW, srcH, TARGET_SIZE);
-            opts.inJustDecodeBounds = false;
-            opts.inPreferredConfig = Bitmap.Config.RGB_565;
-            opts.inTempStorage = DECODE_BUFFER;
-
-            // 3. Load sub-sampled bitmap
-            Bitmap bitmap = BitmapFactory.decodeFile(imageFile.getAbsolutePath(), opts);
-            if (bitmap == null) {
-                Log.e(TAG, "preprocessImage: failed to decode bitmap");
-                return;
-            }
-
-            try {
-                // 4. Build a single Matrix for scale + rotate combined
-                Matrix matrix = new Matrix();
-                float scale = Math.min(
-                        (float) TARGET_SIZE / bitmap.getWidth(),
-                        (float) TARGET_SIZE / bitmap.getHeight());
-                if (scale < 1.0f) {
-                    matrix.postScale(scale, scale);
-                }
-                if (rotation != 0) {
-                    // Rotate around the center of the image
-                    float cx = bitmap.getWidth() * Math.max(scale, 1.0f) / 2f;
-                    float cy = bitmap.getHeight() * Math.max(scale, 1.0f) / 2f;
-                    matrix.postRotate(rotation, cx, cy);
-                }
-
-                // 5. Apply combined transform
-                if (!matrix.isIdentity()) {
-                    Bitmap transformed = Bitmap.createBitmap(bitmap, 0, 0,
-                            bitmap.getWidth(), bitmap.getHeight(), matrix, true);
-                    bitmap.recycle();
-                    bitmap = transformed;
-                }
-
-                // 6. Write processed image back to file
-                try (FileOutputStream fos = new FileOutputStream(imageFile)) {
-                    bitmap.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, fos);
-                }
-                if (debug) {
-                    Log.v(TAG, "preprocessImage: wrote " + bitmap.getWidth() + "x" + bitmap.getHeight()
-                            + " (rotation=" + rotation + ") to " + imageFile.getName());
-                }
-            } finally {
-                bitmap.recycle();
-            }
-        } catch (Exception e) {
-            Log.e(TAG, "preprocessImage failed, falling back to original: " + e.getMessage());
-        }
-    }
-
-    private static int calculateInSampleSize(int width, int height, int targetSize) {
-        int inSampleSize = 1;
-        if (height > targetSize || width > targetSize) {
-            int halfH = height / 2;
-            int halfW = width / 2;
-            while ((halfH / inSampleSize) >= targetSize && (halfW / inSampleSize) >= targetSize) {
-                inSampleSize *= 2;
-            }
-        }
-        return inSampleSize;
-    }
-
     // native
     private native void sendPhotoFile(String originalFilePath, String processedFilePath);
+    private native void sendCancelled();
 
 }

--- a/modules/pictures/src/main/native/android/dalvik/ImagePreprocessor.java
+++ b/modules/pictures/src/main/native/android/dalvik/ImagePreprocessor.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.helloandroid;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+/**
+ * Performs image manipulations after capture or import.
+ * It reduces large images, applies the requested rotation,
+ * and rewrites a compact JPEG for faster loading on the Java side.
+ */
+final class ImagePreprocessor {
+
+    private static final int TARGET_SIZE = 1280;
+    private static final int JPEG_QUALITY = 85;
+    private static final byte[] DECODE_BUFFER = new byte[16 * 1024];
+
+    private ImagePreprocessor() {
+    }
+
+    static void preprocessImage(File imageFile, int rotation, boolean debug, String tag) {
+        try {
+            BitmapFactory.Options opts = new BitmapFactory.Options();
+            opts.inJustDecodeBounds = true;
+            opts.inTempStorage = DECODE_BUFFER;
+            BitmapFactory.decodeFile(imageFile.getAbsolutePath(), opts);
+
+            int srcW = opts.outWidth;
+            int srcH = opts.outHeight;
+            if (rotation == 90 || rotation == 270) {
+                srcW = opts.outHeight;
+                srcH = opts.outWidth;
+            }
+            opts.inSampleSize = calculateInSampleSize(srcW, srcH, TARGET_SIZE);
+            opts.inJustDecodeBounds = false;
+            opts.inPreferredConfig = Bitmap.Config.RGB_565;
+            opts.inTempStorage = DECODE_BUFFER;
+
+            Bitmap bitmap = BitmapFactory.decodeFile(imageFile.getAbsolutePath(), opts);
+            if (bitmap == null) {
+                Log.e(tag, "preprocessImage: failed to decode bitmap");
+                return;
+            }
+
+            try {
+                Matrix matrix = new Matrix();
+                float scale = Math.min(
+                        (float) TARGET_SIZE / bitmap.getWidth(),
+                        (float) TARGET_SIZE / bitmap.getHeight());
+                if (scale < 1.0f) {
+                    matrix.postScale(scale, scale);
+                }
+                if (rotation != 0) {
+                    float cx = bitmap.getWidth() * Math.max(scale, 1.0f) / 2f;
+                    float cy = bitmap.getHeight() * Math.max(scale, 1.0f) / 2f;
+                    matrix.postRotate(rotation, cx, cy);
+                }
+
+                if (!matrix.isIdentity()) {
+                    Bitmap transformed = Bitmap.createBitmap(bitmap, 0, 0,
+                            bitmap.getWidth(), bitmap.getHeight(), matrix, true);
+                    bitmap.recycle();
+                    bitmap = transformed;
+                }
+
+                try (FileOutputStream fos = new FileOutputStream(imageFile)) {
+                    bitmap.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, fos);
+                }
+                if (debug) {
+                    Log.v(tag, "preprocessImage: wrote " + bitmap.getWidth() + "x" + bitmap.getHeight()
+                            + " (rotation=" + rotation + ") to " + imageFile.getName());
+                }
+            } finally {
+                bitmap.recycle();
+            }
+        } catch (Exception e) {
+            Log.e(tag, "preprocessImage failed, falling back to original: " + e.getMessage());
+        }
+    }
+
+    private static int calculateInSampleSize(int width, int height, int targetSize) {
+        int inSampleSize = 1;
+        if (height > targetSize || width > targetSize) {
+            int halfH = height / 2;
+            int halfW = width / 2;
+            while ((halfH / inSampleSize) >= targetSize && (halfW / inSampleSize) >= targetSize) {
+                inSampleSize *= 2;
+            }
+        }
+        return inSampleSize;
+    }
+}
+

--- a/modules/pictures/src/main/native/android/dalvik/PreviewStreamCoverController.java
+++ b/modules/pictures/src/main/native/android/dalvik/PreviewStreamCoverController.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026, Gluon
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL GLUON BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.gluonhq.helloandroid;
+
+import android.view.View;
+
+import androidx.camera.view.PreviewView;
+import androidx.lifecycle.Observer;
+
+/**
+ * Manages the black startup cover shown above the preview surface.
+ * When the Camera stream is ready fades the cover out.
+ */
+final class PreviewStreamCoverController {
+
+    private final PreviewView previewView;
+    private final View startupCover;
+    private Observer<PreviewView.StreamState> previewStreamObserver;
+
+    PreviewStreamCoverController(PreviewView previewView, View startupCover) {
+        this.previewView = previewView;
+        this.startupCover = startupCover;
+    }
+
+    void prepareForBind() {
+        if (startupCover == null) {
+            return;
+        }
+        startupCover.animate().cancel();
+        startupCover.setAlpha(1f);
+        startupCover.setVisibility(View.VISIBLE);
+    }
+
+    void attach() {
+        if (previewView == null || previewStreamObserver != null) {
+            return;
+        }
+        previewStreamObserver = new Observer<PreviewView.StreamState>() {
+            @Override
+            public void onChanged(PreviewView.StreamState streamState) {
+                if (streamState == PreviewView.StreamState.STREAMING && startupCover != null) {
+                    fadeOutStartupCover();
+                }
+            }
+        };
+        previewView.getPreviewStreamState().observeForever(previewStreamObserver);
+    }
+
+    void detach() {
+        if (previewView != null && previewStreamObserver != null) {
+            previewView.getPreviewStreamState().removeObserver(previewStreamObserver);
+            previewStreamObserver = null;
+        }
+    }
+
+    private void fadeOutStartupCover() {
+        if (startupCover == null || startupCover.getVisibility() != View.VISIBLE) {
+            return;
+        }
+        startupCover.animate()
+                .alpha(0f)
+                .setDuration(120)
+                .withEndAction(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (startupCover != null) {
+                            startupCover.setVisibility(View.GONE);
+                            startupCover.setAlpha(1f);
+                        }
+                    }
+                })
+                .start();
+    }
+}
+

--- a/modules/pictures/src/main/resources/META-INF/substrate/dalvik/AndroidManifest.xml
+++ b/modules/pictures/src/main/resources/META-INF/substrate/dalvik/AndroidManifest.xml
@@ -5,16 +5,6 @@
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
-    <application>
-        <provider android:name="com.gluonhq.helloandroid.FileProvider"
-                  android:authorities="${applicationId}.fileprovider"
-                  android:exported="false"
-                  android:grantUriPermissions="true">
-            <meta-data
-                    android:name="android.support.FILE_PROVIDER_PATHS"
-                    android:resource="@xml/file_provider_paths" />
-        </provider>
-    </application>
     <queries>
         <intent>
             <action android:name="android.media.action.IMAGE_CAPTURE" />

--- a/modules/pictures/src/main/resources/META-INF/substrate/dalvik/android-dependencies.txt
+++ b/modules/pictures/src/main/resources/META-INF/substrate/dalvik/android-dependencies.txt
@@ -1,0 +1,6 @@
+implementation 'androidx.camera:camera-core:1.4.2'
+implementation 'androidx.camera:camera-camera2:1.4.2'
+implementation 'androidx.camera:camera-lifecycle:1.4.2'
+implementation 'androidx.camera:camera-view:1.4.2'
+implementation 'com.google.guava:listenablefuture:1.0'
+

--- a/modules/pictures/src/main/resources/META-INF/substrate/dalvik/build.gradle
+++ b/modules/pictures/src/main/resources/META-INF/substrate/dalvik/build.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'com.android.library'
+
+android {
+
+    namespace 'com.gluonhq.helloandroid'
+
+    defaultConfig {
+        minSdkVersion 21
+        compileSdk 35
+        targetSdkVersion 35
+    }
+
+    dependencies {
+        compileOnly fileTree(dir: '../libs', include: '*.jar')
+        implementation 'androidx.camera:camera-core:1.4.2'
+        implementation 'androidx.camera:camera-camera2:1.4.2'
+        implementation 'androidx.camera:camera-lifecycle:1.4.2'
+        implementation 'androidx.camera:camera-view:1.4.2'
+        implementation 'com.google.guava:listenablefuture:1.0'
+    }
+
+    buildFeatures {
+        buildConfig = false
+        resValues = false
+    }
+}
+

--- a/modules/pictures/src/main/resources/META-INF/substrate/dalvik/res/drawable/ic_flip_camera.xml
+++ b/modules/pictures/src/main/resources/META-INF/substrate/dalvik/res/drawable/ic_flip_camera.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,4c4.42,0 8,3.58 8,8h-2c0,-3.31 -2.69,-6 -6,-6v3L8,5l4,-4v3z" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,20c-4.42,0 -8,-3.58 -8,-8h2c0,3.31 2.69,6 6,6v-3l4,4 -4,4v-3z" />
+</vector>
+
+

--- a/modules/pictures/src/main/resources/META-INF/substrate/dalvik/res/xml/file_provider_paths.xml
+++ b/modules/pictures/src/main/resources/META-INF/substrate/dalvik/res/xml/file_provider_paths.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths>
-    <external-path name="external_files" path="." />
-    <cache-path name="cache_files" path="." />
-</paths>


### PR DESCRIPTION
Fixes #443 

- Replaces the Intent to use the external vendor camera application that forced the application to get backgrounded and restored all over again, with a built-in more lightweight overlay that uses the Camera API to take pictures.
- Camera API allows for back and front cameras, zoom, scale and pinch gestures, orientation changes, back and cancel events.

 