### PR TITLE
Add non-predictive text keyboard type

### DIFF
--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/KeyboardType.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/KeyboardType.java
@@ -99,7 +99,16 @@ public enum KeyboardType {
     /**
      * A numeric keypad that outputs only ASCII digits
      */
-    ASCII_NUMBER_PAD(11);
+    ASCII_NUMBER_PAD(11),
+
+    /**
+     * A text keyboard with autocorrection, suggestions and predictive text
+     * disabled. Useful for fields that should accept raw user input
+     * (identifiers, codes, tokens, login input).
+     *
+     * <p>On iOS this value fall back to an ASCII-capable keyboard.</p>
+     */
+    TEXT_NO_SUGGESTIONS(12);
 
     private final int value;
 

--- a/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/KeyboardType.java
+++ b/modules/keyboard/src/main/java/com/gluonhq/attach/keyboard/KeyboardType.java
@@ -106,7 +106,7 @@ public enum KeyboardType {
      * disabled. Useful for fields that should accept raw user input
      * (identifiers, codes, tokens, login input).
      *
-     * <p>On iOS this value fall back to an ASCII-capable keyboard.</p>
+     * <p>On iOS this value falls back to an ASCII-capable keyboard.</p>
      */
     TEXT_NO_SUGGESTIONS(12);
 

--- a/modules/keyboard/src/main/native/ios/Keyboard.m
+++ b/modules/keyboard/src/main/native/ios/Keyboard.m
@@ -120,10 +120,6 @@ static void reloadKeyboard() {
 }
 
 void setGlassKeyboardType(int type) {
-    // fall back to an ASCII-capable keyboard as TEXT_NO_SUGGESTIONS = 12 has no iOS equivalent
-    if (type < 0 || type > 11) {
-        type = (int)UIKeyboardTypeASCIICapable;
-    }
     currentKeyboardType = (UIKeyboardType)type;
     ensureSwizzled();
     AttachLog(@"Keyboard type set to %d", type);
@@ -156,11 +152,17 @@ JNIEXPORT void JNICALL Java_com_gluonhq_attach_keyboard_impl_IOSKeyboardService_
 JNIEXPORT void JNICALL Java_com_gluonhq_attach_keyboard_impl_IOSKeyboardService_nativeSetKeyboardType
 (JNIEnv *env, jclass jClass, jint type)
 {
-    if (keyboardTypeSwizzled && (UIKeyboardType)type == currentKeyboardType) {
+    int keyboardType = (int) type;
+    if (keyboardType < 0 || keyboardType > 11) {
+        // fall back to an ASCII-capable keyboard. I.e. TEXT_NO_SUGGESTIONS = 12 has no iOS equivalent
+        keyboardType = (int) UIKeyboardTypeASCIICapable;
+    }
+
+    if (keyboardTypeSwizzled && (UIKeyboardType)keyboardType == currentKeyboardType) {
         return;
     }
     dispatch_async(dispatch_get_main_queue(), ^{
-        setGlassKeyboardType((int)type);
+        setGlassKeyboardType(keyboardType);
         reloadKeyboard();
     });
 }

--- a/modules/keyboard/src/main/native/ios/Keyboard.m
+++ b/modules/keyboard/src/main/native/ios/Keyboard.m
@@ -120,6 +120,10 @@ static void reloadKeyboard() {
 }
 
 void setGlassKeyboardType(int type) {
+    // fall back to an ASCII-capable keyboard as TEXT_NO_SUGGESTIONS = 12 has no iOS equivalent
+    if (type < 0 || type > 11) {
+        type = (int)UIKeyboardTypeASCIICapable;
+    }
     currentKeyboardType = (UIKeyboardType)type;
     ensureSwizzled();
     AttachLog(@"Keyboard type set to %d", type);


### PR DESCRIPTION
As a follow-up of 165, add a new keyboard type, mainly for Android, that can be used to have text input controls without predictive text (even if user keeps the predictive text enabled in the device settings).
On iOS there is no predictive support yet.